### PR TITLE
Create auto scaling group for ECS DHCP

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,6 +10,7 @@ env:
     TF_VAR_enable_authentication: true
     TF_VAR_admin_db_backup_retention_period: 30
     TF_VAR_enable_dhcp_transit_gateway_attachment: true
+    TF_VAR_enable_ssh_key_generation: false
   parameter-store:
     TF_VAR_assume_role: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
     TF_VAR_dhcp_db_username: "/codebuild/dhcp/$ENV/db/username"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -22,6 +22,9 @@ env:
     TF_VAR_vpn_hosted_zone_domain: "/route53/$ENV/vpn_hosted_zone_domain"
     TF_VAR_dhcp_transit_gateway_id: "/staff-device/dhcp/$ENV/transit_gateway_id"
     TF_VAR_transit_gateway_route_table_id: "/staff-device/dhcp/$ENV/transit_gateway_route_table_id"
+    TF_VAR_load_balancer_private_ip_eu_west_2a: "/staff-device/dhcp/$ENV/load_balancer_private_ip_eu_west_2a"
+    TF_VAR_load_balancer_private_ip_eu_west_2b: "/staff-device/dhcp/$ENV/load_balancer_private_ip_eu_west_2b"
+    TF_VAR_load_balancer_private_ip_eu_west_2c: "/staff-device/dhcp/$ENV/load_balancer_private_ip_eu_west_2c"
 
 phases:
   install:

--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,15 @@ provider "tls" {
 }
 
 provider "aws" {
-  version = "~> 2.68"
+  version = "~> 3.3"
   alias   = "env"
   assume_role {
     role_arn = var.assume_role
   }
+}
+
+provider "local" {
+  version = "~> 1.4"
 }
 
 module "dhcp_label" {
@@ -83,6 +87,9 @@ module "dhcp" {
   dhcp_transit_gateway_id                = var.dhcp_transit_gateway_id
   enable_dhcp_transit_gateway_attachment = var.enable_dhcp_transit_gateway_attachment
   transit_gateway_route_table_id         = var.transit_gateway_route_table_id
+  load_balancer_private_ip_eu_west_2a    = var.load_balancer_private_ip_eu_west_2a
+  load_balancer_private_ip_eu_west_2b    = var.load_balancer_private_ip_eu_west_2b
+  load_balancer_private_ip_eu_west_2c    = var.load_balancer_private_ip_eu_west_2c
 
   providers = {
     aws = aws.env

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ module "dhcp" {
   load_balancer_private_ip_eu_west_2a    = var.load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b    = var.load_balancer_private_ip_eu_west_2b
   load_balancer_private_ip_eu_west_2c    = var.load_balancer_private_ip_eu_west_2c
+  enable_ssh_key_generation              = var.enable_ssh_key_generation
 
   providers = {
     aws = aws.env

--- a/modules/dhcp/auto_scaling_group.tf
+++ b/modules/dhcp/auto_scaling_group.tf
@@ -1,15 +1,51 @@
-resource "aws_instance" "dhcp_server" {
-  ami           = data.aws_ami.dhcp_server.id
+resource "aws_autoscaling_group" "dhcp_auto_scaling_group" {
+  name                      = aws_launch_configuration.dhcp_launch_configuration.name
+  max_size                  = 2
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "EC2"
+  desired_capacity          = 2
+  force_delete              = true
+  placement_group           = aws_placement_group.dhcp_placement_group.id
+  launch_configuration      = aws_launch_configuration.dhcp_launch_configuration.name
+  vpc_zone_identifier       = var.subnets
+  wait_for_capacity_timeout = "20m"
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = "true"
+    propagate_at_launch = true
+  }
+
+  timeouts {
+    delete = "15m"
+  }
+
+}
+
+resource "aws_placement_group" "dhcp_placement_group" {
+  name     = "${var.prefix}-placement-group"
+  strategy = "spread"
+
+  tags = var.tags
+}
+
+resource "tls_private_key" "ec2" {
+  algorithm = "RSA"
+}
+resource "aws_key_pair" "bastion_public_key_pair" {
+  key_name   = var.prefix
+  public_key = tls_private_key.ec2.public_key_openssh
+  tags       = var.tags
+}
+
+resource "aws_launch_configuration" "dhcp_launch_configuration" {
+  image_id      = data.aws_ami.dhcp_server.id
+  security_groups = [aws_security_group.dhcp_server.id]
   instance_type = "t2.medium"
-  subnet_id     = var.subnets[1]
-
-  vpc_security_group_ids = [
-    aws_security_group.dhcp_server.id
-  ]
-  associate_public_ip_address = true
   iam_instance_profile = aws_iam_instance_profile.ecs_instance_profile.id
-  monitoring           = true
-
+  enable_monitoring = true
+  key_name = aws_key_pair.bastion_public_key_pair.key_name
   user_data = <<DATA
 Content-Type: multipart/mixed; boundary="==BOUNDARY=="
 MIME-Version: 1.0
@@ -55,7 +91,7 @@ MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
 # Set cluster name
-echo ECS_CLUSTER=${aws_ecs_cluster.server_cluster.name} >> /etc/ecs/ecs.config
+echo ECS_CLUSTER=${var.prefix}-cluster >> /etc/ecs/ecs.config
 
 --==BOUNDARY==
 MIME-Version: 1.0
@@ -148,9 +184,7 @@ end script
 
 DATA
 
-  tags = var.tags
-
-  lifecycle {
+lifecycle {
     create_before_destroy = true
   }
 }

--- a/modules/dhcp/main.tf
+++ b/modules/dhcp/main.tf
@@ -1,11 +1,21 @@
 resource "aws_lb" "load_balancer" {
   name               = var.prefix
-  internal           = false
   load_balancer_type = "network"
+  internal = true
 
   subnet_mapping {
     subnet_id     = var.subnets[0]
-    allocation_id = aws_eip.public_ip.id
+    private_ipv4_address = var.load_balancer_private_ip_eu_west_2a
+  }
+
+  subnet_mapping {
+    subnet_id     = var.subnets[1]
+    private_ipv4_address = var.load_balancer_private_ip_eu_west_2b
+  }
+
+  subnet_mapping {
+    subnet_id     = var.subnets[2]
+    private_ipv4_address = var.load_balancer_private_ip_eu_west_2c
   }
 
   enable_deletion_protection = false
@@ -23,12 +33,6 @@ resource "aws_lb_target_group" "target_group" {
     protocol = "TCP"
     port = 80
   }
-}
-
-resource "aws_lb_target_group_attachment" "target_group_attachment" {
-  target_group_arn = aws_lb_target_group.target_group.arn
-  target_id        = aws_instance.dhcp_server.id
-  port             = 67
 }
 
 resource "aws_lb_listener" "udp" {

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -19,16 +19,15 @@ output "kea_config_bucket_name" {
 }
 
 output "ssh_keypair_name" {
-  value = aws_key_pair.bastion_public_key_pair.key_name
+  value = var.enable_ssh_key_generation ? aws_key_pair.dhcp_public_key_pair.*.key_name[0] : ""
 }
 
 resource "local_file" "ec2_private_key" {
   filename          = "ec2.pem"
   file_permission   = "0600"
-  sensitive_content = tls_private_key.ec2.private_key_pem
+  sensitive_content = var.enable_ssh_key_generation ? tls_private_key.ec2.*.private_key_pem[0] : ""
 }
 
 output "ssh_private_key" {
-  value = tls_private_key.ec2.private_key_pem
+  value = var.enable_ssh_key_generation ? tls_private_key.ec2.*.private_key_pem[0] : ""
 }
-

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -17,3 +17,18 @@ output "kea_config_bucket_arn" {
 output "kea_config_bucket_name" {
   value = aws_s3_bucket.config_bucket.id
 }
+
+output "ssh_keypair_name" {
+  value = aws_key_pair.bastion_public_key_pair.key_name
+}
+
+resource "local_file" "ec2_private_key" {
+  filename          = "ec2.pem"
+  file_permission   = "0600"
+  sensitive_content = tls_private_key.ec2.private_key_pem
+}
+
+output "ssh_private_key" {
+  value = tls_private_key.ec2.private_key_pem
+}
+

--- a/modules/dhcp/s3.tf
+++ b/modules/dhcp/s3.tf
@@ -1,0 +1,25 @@
+
+resource "aws_s3_bucket" "config_bucket" {
+  bucket = "${var.prefix}-config-bucket"
+  acl    = "private"
+  tags   = var.tags
+  versioning {
+    enabled = true
+  }
+}
+
+data "template_file" "config_bucket_policy" {
+  template = file("${path.module}/policies/config_bucket_policy.json")
+
+  vars = {
+    config_bucket_arn = aws_s3_bucket.config_bucket.arn,
+    ecs_task_role_arn = aws_iam_role.ecs_task_role.arn
+  }
+}
+
+resource "aws_s3_bucket_policy" "config_bucket_policy" {
+  bucket = aws_s3_bucket.config_bucket.id
+
+  policy = data.template_file.config_bucket_policy.rendered
+}
+

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -41,3 +41,15 @@ variable "enable_dhcp_transit_gateway_attachment" {
 variable "transit_gateway_route_table_id" {
   type = string
 }
+
+variable "load_balancer_private_ip_eu_west_2a" {
+  type = string
+}
+
+variable "load_balancer_private_ip_eu_west_2b" {
+  type = string
+}
+
+variable "load_balancer_private_ip_eu_west_2c" {
+  type = string
+}

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -53,3 +53,7 @@ variable "load_balancer_private_ip_eu_west_2b" {
 variable "load_balancer_private_ip_eu_west_2c" {
   type = string
 }
+
+variable "enable_ssh_key_generation" {
+  type = bool
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.44.0"
+  version = "2.48.0"
   name    = var.prefix
 
   cidr               = var.cidr_block

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,20 @@ variable "enable_dhcp_transit_gateway_attachment" {
 variable "transit_gateway_route_table_id" {
   type    = string
 }
+
+variable "enable_ssh_key_generation" {
+  type = bool
+  default = true
+}
+
+variable "load_balancer_private_ip_eu_west_2a" {
+  type = string
+}
+
+variable "load_balancer_private_ip_eu_west_2b" {
+  type = string
+}
+
+variable "load_balancer_private_ip_eu_west_2c" {
+  type = string
+}


### PR DESCRIPTION
This used to be just a single instance. Now using an auto scaling group
attached to the network load balancer, this will allow us to do smoke
testing in a more production like environment.

Requires bumping the AWS provider to assign private IPs to the load
balancers.