### PR TITLE
Fix domain validation bug with new AWS provider

### DIFF
--- a/modules/admin/acm.tf
+++ b/modules/admin/acm.tf
@@ -11,5 +11,5 @@ resource "aws_acm_certificate" "admin_lb" {
 
 resource "aws_acm_certificate_validation" "admin_lb" {
   certificate_arn         = aws_acm_certificate.admin_lb.arn
-  validation_record_fqdns = [for record in aws_route53_record.admin_lb_verification : record.fqdn]
+  validation_record_fqdns = [aws_route53_record.admin_lb_verification.fqdn]
 }

--- a/modules/admin/route53.tf
+++ b/modules/admin/route53.tf
@@ -15,19 +15,14 @@ resource "aws_route53_record" "admin_lb" {
   }
 }
 
+
 resource "aws_route53_record" "admin_lb_verification" {
   zone_id = var.vpn_hosted_zone_id
   ttl     = 60
 
-  for_each = {
-    for dvo in aws_acm_certificate.admin_lb.domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
+  name   = tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_name
+  records = [tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_value]
+  type   = tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_type
 
-  name    = each.value.name
-  records = [each.value.record]
-  type    = each.value.type
 }
+


### PR DESCRIPTION
Using a for requires a two step apply in terraform. This is due to an upgrade in the AWS provider. Side step this issue by using the old tolist() syntax.