### PR TITLE
Conditionally create custom domain for Admin LB

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ env:
     TF_VAR_admin_db_backup_retention_period: 30
     TF_VAR_enable_dhcp_transit_gateway_attachment: true
     TF_VAR_enable_ssh_key_generation: false
+    TF_VAR_enable_custom_domain_name: true
   parameter-store:
     TF_VAR_assume_role: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
     TF_VAR_dhcp_db_username: "/codebuild/dhcp/$ENV/db/username"

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ module "admin" {
   dhcp_cluster_name                = module.dhcp.ecs.cluster_name
   dhcp_service_name                = module.dhcp.ecs.service_name
   dhcp_service_arn                 = module.dhcp.ecs.service_arn
+  enable_custom_domain_name        = var.enable_custom_domain_name
 
   providers = {
     aws = aws.env

--- a/modules/admin/acm.tf
+++ b/modules/admin/acm.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "admin_lb" {
-  domain_name       = aws_route53_record.admin_lb.fqdn
+  domain_name       = local.lb_verification_record_fqdn
   validation_method = "DNS"
 
   lifecycle {
@@ -9,7 +9,11 @@ resource "aws_acm_certificate" "admin_lb" {
   tags = var.tags
 }
 
+locals {
+  lb_verification_record_fqdn = var.enable_custom_domain_name ? aws_route53_record.admin_lb[0].fqdn : aws_lb.admin_alb.dns_name
+}
+
 resource "aws_acm_certificate_validation" "admin_lb" {
   certificate_arn         = aws_acm_certificate.admin_lb.arn
-  validation_record_fqdns = [aws_route53_record.admin_lb_verification.fqdn]
+  validation_record_fqdns = [local.lb_verification_record_fqdn]
 }

--- a/modules/admin/loadbalancer.tf
+++ b/modules/admin/loadbalancer.tf
@@ -19,7 +19,7 @@ resource "aws_alb_listener" "alb_listener" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
-  certificate_arn   = aws_acm_certificate.admin_lb.arn
+  certificate_arn   =  aws_acm_certificate.admin_lb.arn
 
   default_action {
     target_group_arn = aws_alb_target_group.admin_tg.arn

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -3,5 +3,5 @@ output "admin_db_identifier" {
 }
 
 output "admin_url" {
-  value = aws_route53_record.admin_lb.fqdn
+  value = var.enable_custom_domain_name ? aws_route53_record.admin_lb[0].fqdn : aws_lb.admin_alb.dns_name
 }

--- a/modules/admin/route53.tf
+++ b/modules/admin/route53.tf
@@ -1,4 +1,9 @@
+locals {
+  enable_custom_domain_name = var.enable_custom_domain_name ? 1 : 0
+}
+
 resource "aws_route53_record" "admin_lb" {
+  count          = local.enable_custom_domain_name
   zone_id        = var.vpn_hosted_zone_id
   name           = "staff-device-admin-${var.short_prefix}.${var.vpn_hosted_zone_domain}"
   type           = "A"
@@ -15,14 +20,14 @@ resource "aws_route53_record" "admin_lb" {
   }
 }
 
-
 resource "aws_route53_record" "admin_lb_verification" {
+  count   = local.enable_custom_domain_name
   zone_id = var.vpn_hosted_zone_id
   ttl     = 60
 
-  name   = tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_name
+  name    = tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_name
   records = [tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_value]
-  type   = tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_type
+  type    = tolist(aws_acm_certificate.admin_lb.domain_validation_options)[0].resource_record_type
 
 }
 

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -88,3 +88,7 @@ variable "dhcp_service_name" {
 variable "dhcp_service_arn" {
   type = string
 }
+
+variable "enable_custom_domain_name" {
+  type = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -100,3 +100,8 @@ variable "dns_load_balancer_private_ip_eu_west_2b" {
 variable "dns_load_balancer_private_ip_eu_west_2c" {
   type = string
 }
+
+variable "enable_custom_domain_name" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
Always create the certificates, but conditionally assign them to either
the route53 record (created when run on CI), or on the dns name for the
load balancer (when run from local).