### PR TITLE
Modify Security Groups to be restrictive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,10 @@ module "dhcp_label" {
 data "aws_region" "current_region" {}
 data "aws_caller_identity" "shared_services_account" {}
 
+locals {
+  dns_dhcp_vpc_cidr = "10.180.80.0/22"
+}
+
 module "vpc" {
   source              = "./modules/vpc"
   prefix              = module.dhcp_label.id
@@ -100,6 +104,7 @@ module "dhcp" {
   short_prefix                           = module.dhcp_label.stage # avoid 32 char limit on certain resources
   region                                 = data.aws_region.current_region.id
   is_publicly_accessible                 = local.publicly_accessible
+  vpc_cidr                               = local.dns_dhcp_vpc_cidr
 
   providers = {
     aws = aws.env
@@ -185,6 +190,7 @@ module "dns" {
   load_balancer_private_ip_eu_west_2b = var.dns_load_balancer_private_ip_eu_west_2b
   load_balancer_private_ip_eu_west_2c = var.dns_load_balancer_private_ip_eu_west_2c
   vpc_id                              = module.vpc.vpc_id
+  vpc_cidr                            = local.dns_dhcp_vpc_cidr
 
   depends_on = [
     module.vpc

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -171,7 +171,7 @@ resource "aws_ecs_service" "admin-service" {
     subnets = var.subnet_ids
 
     security_groups = [
-      aws_security_group.admin_ecs_out.id
+      aws_security_group.admin_ecs.id
     ]
 
     assign_public_ip = true

--- a/modules/admin/db.tf
+++ b/modules/admin/db.tf
@@ -15,7 +15,7 @@ resource "aws_db_instance" "admin_db" {
   multi_az                    = true
   storage_encrypted           = true
   db_subnet_group_name        = aws_db_subnet_group.admin_db_group.name
-  vpc_security_group_ids      = [aws_security_group.admin_db_in.id]
+  vpc_security_group_ids      = [aws_security_group.admin_db.id]
   monitoring_role_arn         = aws_iam_role.rds_monitoring_role.arn
   monitoring_interval         = 60
   skip_final_snapshot         = true

--- a/modules/admin/loadbalancer.tf
+++ b/modules/admin/loadbalancer.tf
@@ -4,8 +4,7 @@ resource "aws_lb" "admin_alb" {
   subnets  = var.subnet_ids
 
   security_groups = [
-    aws_security_group.admin_alb_in.id,
-    aws_security_group.admin_alb_out.id
+    aws_security_group.admin_alb.id
   ]
 
   load_balancer_type = "application"

--- a/modules/admin/security_groups.tf
+++ b/modules/admin/security_groups.tf
@@ -14,11 +14,11 @@ resource "aws_security_group" "admin_alb" {
 }
 
 resource "aws_security_group_rule" "admin_alb_out" {
-  type              = "egress"
-  from_port         = 3000
-  to_port           = 3000
-  protocol          = "tcp"
-  security_group_id = aws_security_group.admin_alb.id
+  type                     = "egress"
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.admin_alb.id
   source_security_group_id = aws_security_group.admin_ecs.id
 }
 
@@ -28,9 +28,9 @@ resource "aws_security_group" "admin_db" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port   = 3306
-    to_port     = 3306
-    protocol    = "tcp"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
     security_groups = [aws_security_group.admin_ecs.id]
   }
 
@@ -53,10 +53,10 @@ resource "aws_security_group" "admin_ecs" {
 }
 
 resource "aws_security_group_rule" "admin_ecs_in" {
-  type              = "ingress"
-  from_port         = 3000
-  to_port           = 3000
-  protocol          = "tcp"
-  security_group_id = aws_security_group.admin_ecs.id
+  type                     = "ingress"
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.admin_ecs.id
   source_security_group_id = aws_security_group.admin_alb.id
 }

--- a/modules/dhcp/security_groups.tf
+++ b/modules/dhcp/security_groups.tf
@@ -4,41 +4,40 @@ resource "aws_security_group" "dhcp_server" {
   vpc_id      = var.vpc_id
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 67
+    to_port     = 67
+    protocol    = "udp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
   }
 
   tags = var.tags
 }
 
 resource "aws_security_group" "dhcp_db_in" {
-  name        = "dhcp-db-in"
+  name        = "${var.prefix}-dhcp-db-in"
   description = "Allow connections to the DB"
   vpc_id      = var.vpc_id
 
-  tags = var.tags
-
   ingress {
-    from_port = 0
-    to_port   = 0
-    protocol  = -1
-    #cidr_blocks = var.public_subnet_cidr_blocks
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.dhcp_server.id]
   }
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  tags = var.tags
 }

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -18,6 +18,10 @@ variable "vpc_id" {
   type = string
 }
 
+variable "vpc_cidr" {
+  type = string
+}
+
 variable "dhcp_db_username" {
   type = string
 }

--- a/modules/dns/security_groups.tf
+++ b/modules/dns/security_groups.tf
@@ -4,17 +4,24 @@ resource "aws_security_group" "dns_server" {
   vpc_id      = var.vpc_id
 
   egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = -1
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
   }
 
   tags = var.tags

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -14,6 +14,10 @@ variable "vpc_id" {
   type = string
 }
 
+variable "vpc_cidr" {
+  type = string
+}
+
 variable "critical_notifications_arn" {
   type = string
 }


### PR DESCRIPTION
These were open during development of the services, locking this down so
only required ports and cidr ranges are accesible.