### PR TITLE
Make user roles mutable

### DIFF
--- a/modules/authentication/main.tf
+++ b/modules/authentication/main.tf
@@ -10,6 +10,7 @@ resource "aws_cognito_user_pool" "pool" {
   schema {
     name                     = "app_role"
     attribute_data_type      = "String"
+    mutable                  = true
 
     string_attribute_constraints {
         min_length = 1


### PR DESCRIPTION
If a users role is changed in Azure, after they authorize, the role
is immutable in cognito. We need user roles to be mutable in cognito
to allow roles to change after first sign in, or more pertinently
after cognito has persisted the user in the pool.