### PR TITLE
Manage module dependencies by upgrading Terraform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 init:
-	terraform init --backend-config="key=terraform.development.state"
+	terraform init -reconfigure --backend-config="key=terraform.development.state"
 
 .PHONY: init

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,14 +33,14 @@ env:
 phases:
   install:
     commands:
-      - wget --no-verbose -O terraform.zip https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip
+      - wget --no-verbose -O terraform.zip https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_amd64.zip
       - unzip terraform.zip
       - mv terraform /bin
 
   build:
     commands:
       - export AWS_DEFAULT_REGION=eu-west-2
-      - terraform init -no-color --backend-config="key=terraform.$ENV.state"
+      - terraform init -reconfigure -no-color --backend-config="key=terraform.$ENV.state"
       - terraform workspace new $ENV || true
       - terraform workspace select $ENV
       - terraform apply --auto-approve -no-color

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "> 0.12.0"
+  required_version = "> 0.13.0"
 
   backend "s3" {
     bucket         = "pttp-ci-infrastructure-dns-dhcp-client-core-tf-state"
@@ -30,7 +30,7 @@ provider "local" {
 
 module "dhcp_label" {
   source  = "cloudposse/label/null"
-  version = "0.16.0"
+  version = "0.19.2"
 
   namespace = "staff-device"
   stage     = terraform.workspace
@@ -99,6 +99,10 @@ module "dhcp" {
   providers = {
     aws = aws.env
   }
+
+  depends_on = [
+    module.vpc
+  ]
 }
 
 module "admin" {
@@ -127,6 +131,10 @@ module "admin" {
   dhcp_service_arn                 = module.dhcp.ecs.service_arn
   bind_config_bucket_name          = module.dns.bind_config_bucket_name
   bind_config_bucket_arn           = module.dns.bind_config_bucket_arn
+
+  depends_on = [
+    module.admin_vpc
+  ]
 
   providers = {
     aws = aws.env
@@ -170,6 +178,11 @@ module "dns" {
   load_balancer_private_ip_eu_west_2b = var.dns_load_balancer_private_ip_eu_west_2b
   load_balancer_private_ip_eu_west_2c = var.dns_load_balancer_private_ip_eu_west_2c
   vpc_id                              = module.vpc.vpc_id
+
+  depends_on = [
+    module.vpc
+  ]
+
   providers = {
     aws = aws.env
   }
@@ -177,7 +190,7 @@ module "dns" {
 
 module "dns_label" {
   source  = "cloudposse/label/null"
-  version = "0.16.0"
+  version = "0.19.2"
 
   namespace = "staff-device"
   stage     = terraform.workspace


### PR DESCRIPTION
We are seeing dependency issues when running `terraform destroy`
Two issues are preventing a clean destroy:

1. Terraform attempts to destroy network resources before other
resources. This fails because you cannot destroy a VPC when you have
services running in it.

2. Terraform attempts to destroy the ECS cluster before the auto scaling
group that serves as the compute for the capacity provider.

This PR addresses the first issue, by leveraging the module `depends_on`
feature in Terraform 0.13.

The second issue still needs to be addressed by extracting the auto
scaling group into its own module and having the ECS cluster depend on
it. https://github.com/terraform-providers/terraform-provider-aws/issues/4852

To use this for local development, run `make init`, which will
reconfigure the state to use the new version of Terraform.

A PR following this will remove the `-reconfigure` flag from the
Makefile once everyone has upgraded.