### PR TITLE
Manually remove auto scaling groups before destroy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 init:
-	terraform init --backend-config="key=terraform.development.state"
+	terraform init -reconfigure --backend-config="key=terraform.development.state"
 
 .PHONY: init

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
 init:
 	terraform init -reconfigure --backend-config="key=terraform.development.state"
 
-.PHONY: init
+destroy:
+	aws-vault exec moj-pttp-development -- ./scripts/development_delete_auto_scaling_group_workaround
+	aws-vault exec moj-pttp-shared-services -- terraform destroy
+
+.PHONY: init destroy

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,14 +33,14 @@ env:
 phases:
   install:
     commands:
-      - wget --no-verbose -O terraform.zip https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip
+      - wget --no-verbose -O terraform.zip https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_amd64.zip
       - unzip terraform.zip
       - mv terraform /bin
 
   build:
     commands:
       - export AWS_DEFAULT_REGION=eu-west-2
-      - terraform init -no-color --backend-config="key=terraform.$ENV.state"
+      - terraform init -reconfigure -no-color --backend-config="key=terraform.$ENV.state"
       - terraform workspace new $ENV || true
       - terraform workspace select $ENV
       - terraform apply --auto-approve -no-color

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "> 0.12.0"
+  required_version = "> 0.13.0"
 
   backend "s3" {
     bucket         = "pttp-ci-infrastructure-dns-dhcp-client-core-tf-state"
@@ -30,7 +30,7 @@ provider "local" {
 
 module "dhcp_label" {
   source  = "cloudposse/label/null"
-  version = "0.16.0"
+  version = "0.19.2"
 
   namespace = "staff-device"
   stage     = terraform.workspace
@@ -99,6 +99,10 @@ module "dhcp" {
   providers = {
     aws = aws.env
   }
+
+  depends_on = [
+    module.vpc
+  ]
 }
 
 module "admin" {
@@ -127,6 +131,10 @@ module "admin" {
   dhcp_service_arn                 = module.dhcp.ecs.service_arn
   bind_config_bucket_name          = module.dns.bind_config_bucket_name
   bind_config_bucket_arn           = module.dns.bind_config_bucket_arn
+
+  depends_on = [
+    module.admin_vpc
+  ]
 
   providers = {
     aws = aws.env
@@ -170,6 +178,11 @@ module "dns" {
   load_balancer_private_ip_eu_west_2b = var.dns_load_balancer_private_ip_eu_west_2b
   load_balancer_private_ip_eu_west_2c = var.dns_load_balancer_private_ip_eu_west_2c
   vpc_id                              = module.vpc.vpc_id
+
+  depends_on = [
+    module.vpc
+  ]
+
   providers = {
     aws = aws.env
   }
@@ -177,7 +190,7 @@ module "dns" {
 
 module "dns_label" {
   source  = "cloudposse/label/null"
-  version = "0.16.0"
+  version = "0.19.2"
 
   namespace = "staff-device"
   stage     = terraform.workspace

--- a/modules/dns_dhcp_common/auto_scaling_group.tf
+++ b/modules/dns_dhcp_common/auto_scaling_group.tf
@@ -23,6 +23,12 @@ resource "aws_autoscaling_group" "auto_scaling_group" {
     propagate_at_launch = true
   }
 
+  tag {
+    key                 = "Workspace"
+    value               = terraform.workspace
+    propagate_at_launch = true
+  }
+
   dynamic "tag" {
     for_each = var.tags
 

--- a/scripts/development_delete_auto_scaling_group_workaround
+++ b/scripts/development_delete_auto_scaling_group_workaround
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+current_workspace=$(terraform workspace show)
+
+for group in $(aws autoscaling describe-auto-scaling-groups --query "AutoScalingGroups[? Tags[? (Key=='Workspace') && Value=='${current_workspace}']].AutoScalingGroupName" --output text)
+do
+    echo "Deleting $group"
+    aws autoscaling delete-auto-scaling-group --auto-scaling-group-name ${group} --force-delete
+done
+


### PR DESCRIPTION
Due to a bug in Terraform, ECS is unable to delete before the auto
scaling group has been removed.

Use the aws command line in combination with your current workspace to
delete the auto scaling group as a separate step before running
terraform destroy.

This is wrapped up in `make destroy`, and `terraform destroy` should not
be used.

Because calling aws from the command line is unable to assume a role
unless the arn is known, the `aws-vault` commands need to be hardcoded
within the Makefile.