### PR TITLE
Remove database option and parameter groups

### DIFF
--- a/modules/admin/db.tf
+++ b/modules/admin/db.tf
@@ -1,45 +1,3 @@
-resource "aws_db_parameter_group" "db_parameters" {
-  name        = "${var.prefix}-db-parameter-group"
-  family      = "mysql5.7"
-  description = "DB parameter configuration for admin"
-
-  parameter {
-    name  = "slow_query_log"
-    value = 1
-  }
-
-  parameter {
-    name  = "general_log"
-    value = 0
-  }
-
-  parameter {
-    name  = "log_queries_not_using_indexes"
-    value = 1
-  }
-
-  parameter {
-    name  = "log_output"
-    value = "FILE"
-  }
-
-  tags = var.tags
-}
-
-resource "aws_db_option_group" "mariadb_audit" {
-  name = "${var.prefix}-db-audit"
-
-  option_group_description = "Mariadb audit configuration for DNS / DHCP admin"
-  engine_name              = "mysql"
-  major_engine_version     = "5.7"
-
-  option {
-    option_name = "MARIADB_AUDIT_PLUGIN"
-  }
-
-  tags = var.tags
-}
-
 resource "aws_db_instance" "admin_db" {
   allocated_storage           = 20
   storage_type                = "gp2"
@@ -64,11 +22,7 @@ resource "aws_db_instance" "admin_db" {
   deletion_protection         = false
   publicly_accessible         = true
 
-
-
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
-  option_group_name               = aws_db_option_group.mariadb_audit.name
-  parameter_group_name            = aws_db_parameter_group.db_parameters.name
 
   tags = var.tags
 }

--- a/modules/dhcp/mysql.tf
+++ b/modules/dhcp/mysql.tf
@@ -25,55 +25,6 @@ resource "aws_db_instance" "dhcp_server_db" {
   deletion_protection         = false
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
-  option_group_name               = aws_db_option_group.mariadb_audit.name
-  parameter_group_name            = aws_db_parameter_group.db_parameters.name
-
-  tags = var.tags
-}
-
-resource "aws_db_option_group" "mariadb_audit" {
-  name = "${var.prefix}-db-audit"
-
-  option_group_description = "Mariadb audit configuration for DHCP server database"
-  engine_name              = "mysql"
-  major_engine_version     = "5.7"
-
-  option {
-    option_name = "MARIADB_AUDIT_PLUGIN"
-  }
-
-  tags = var.tags
-}
-
-resource "aws_db_parameter_group" "db_parameters" {
-  name        = "${var.prefix}-db-parameter-group"
-  family      = "mysql5.7"
-  description = "DB parameter configuration for DHCP server"
-
-  parameter {
-    name  = "slow_query_log"
-    value = 1
-  }
-
-  parameter {
-    name  = "general_log"
-    value = 0
-  }
-
-  parameter {
-    name  = "log_queries_not_using_indexes"
-    value = 1
-  }
-
-  parameter {
-    name  = "log_bin_trust_function_creators"
-    value = 1
-  }
-
-  parameter {
-    name  = "log_output"
-    value = "FILE"
-  }
 
   tags = var.tags
 }


### PR DESCRIPTION
These allow fine grained control over the logs that the db instances
generate. The defaults are good enough and activity can be derived from
other logs.

These two resources in combination with automated backups can cause
Terraform to hang in some instances.

A bug in Terraform ignores the skip_final_snapshot configuration and
causes a timeout when destroying: https://github.com/hashicorp/terraform/issues/5417