### PR TITLE
ECS policy depends on ECS service

### DIFF
--- a/modules/dns_dhcp_common/iam.tf
+++ b/modules/dns_dhcp_common/iam.tf
@@ -54,6 +54,10 @@ resource "aws_iam_role_policy" "ecs_instance_policy" {
   ]
 }
 EOF
+
+  depends_on = [
+    aws_ecs_service.service
+  ]
 }
 
 resource "aws_iam_role" "ecs_instance_role" {


### PR DESCRIPTION
As per the Terraform documentation, adding this explicit dependency can
sidestep issues where the IAM policy is removed before the service.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service