### PR TITLE
Review user data in AutoScalingGroup launch configuration

### DIFF
--- a/modules/dns_dhcp_common/auto_scaling_group.tf
+++ b/modules/dns_dhcp_common/auto_scaling_group.tf
@@ -74,7 +74,7 @@ repo_upgrade: all
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
-sudo yum install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https -y
+sudo yum -y install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https
 sudo yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip
 mkdir -p /home/ec2-user/scripts
 cd /home/ec2-user/scripts

--- a/modules/dns_dhcp_common/auto_scaling_group.tf
+++ b/modules/dns_dhcp_common/auto_scaling_group.tf
@@ -74,6 +74,7 @@ repo_upgrade: all
 MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html
 sudo yum -y install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https
 sudo yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip
 mkdir -p /home/ec2-user/scripts

--- a/modules/dns_dhcp_common/auto_scaling_group.tf
+++ b/modules/dns_dhcp_common/auto_scaling_group.tf
@@ -75,8 +75,8 @@ MIME-Version: 1.0
 Content-Type: text/x-shellscript; charset="us-ascii"
 #!/bin/bash
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html
-sudo yum -y install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https
-sudo yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip
+yum -y install perl-Switch perl-DateTime perl-Sys-Syslog perl-LWP-Protocol-https
+yum -y install perl-Digest-SHA perl-URI perl-libwww-perl perl-MIME-tools perl-Crypt-SSLeay perl-XML-LibXML unzip
 mkdir -p /home/ec2-user/scripts
 cd /home/ec2-user/scripts
 curl https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip -O

--- a/modules/dns_dhcp_common/auto_scaling_group.tf
+++ b/modules/dns_dhcp_common/auto_scaling_group.tf
@@ -89,16 +89,17 @@ cd /home/ec2-user/scripts/mon
 
 EOF
 
-sudo cp ./crontab /etc/crontab
+cp ./crontab /etc/crontab
 
 cat <<'EOF' > ./security-updates
 #!/bin/bash
-sudo yum update -y --security
-sudo yum update -y ecs-init
+yum update -y --security
+yum update -y ecs-init
 EOF
 
 chmod +x ./security-updates
-sudo cp ./security-updates /etc/cron.daily
+
+cp ./security-updates /etc/cron.daily
 
 --==BOUNDARY==
 MIME-Version: 1.0


### PR DESCRIPTION
The user_data was reviewed to ensure no extra data, libs or configs exist.

Two very minor edits made and  logs confirmed in AWS cloudwatch.