### PR TITLE
Test DHCP from Corsham

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,35 @@ The code for building this container can be found [here](https://github.com/mini
 Azure AD provides our authorization backend and is not provisioned through CLI/Terraform. Follow this guide for manual steps to build Azure AD infrastructure.
 
 [Azure AD manual provisioning guide](docs/azure_ad.md)
+
+## Corsham Test site
+
+We do remote testing of the DHCP service from a virtual machine running in Corsham.
+To access this VM you need to go through the bastion set up in production, which is on the same network (via the Transit Gateway) as the VM.
+
+### Bastion details:
+
+SSH key - `/corsham/testing/bastion/private_key`
+
+Once on the Bastion run:
+
+```bash
+ssh root@<VM_IP_ADDRESS>
+```
+
+### VM details:
+
+IP address - `/corsham/testing/vm/ip_address`
+Password - `/corsham/testing/vm/password`
+
+Once on the VM, we have a Docker container, provisioned with perfDHCP that can be used to run the tests.
+
+Run:
+```bash
+cd ~/smoke_test
+docker build --network host -t test .
+docker run --network host -t test
+```
+
+This will run perfDHCP against the production DHCP Network load balancers.
+The output will display the test results.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Azure AD provides our authorization backend and is not provisioned through CLI/T
 We do remote testing of the DHCP service from a virtual machine running in Corsham.
 To access this VM you need to go through the bastion set up in production, which is on the same network (via the Transit Gateway) as the VM.
 
+The credentials below for the SSH key, IP address and password are kept in SSM parameter store in production.
+
 ### Bastion details:
 
 SSH key - `/corsham/testing/bastion/private_key`
@@ -73,6 +75,7 @@ ssh root@<VM_IP_ADDRESS>
 ### VM details:
 
 IP address - `/corsham/testing/vm/ip_address`
+
 Password - `/corsham/testing/vm/password`
 
 Once on the VM, we have a Docker container, provisioned with perfDHCP that can be used to run the tests.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The credentials below for the SSH key, IP address and password are kept in SSM p
 
 SSH key - `/corsham/testing/bastion/private_key`
 
-Once on the Bastion run:
+Once you have SSH'd onto the Bastion, run:
 
 ```bash
 ssh root@<VM_IP_ADDRESS>
@@ -78,7 +78,7 @@ IP address - `/corsham/testing/vm/ip_address`
 
 Password - `/corsham/testing/vm/password`
 
-Once on the VM, we have a Docker container, provisioned with perfDHCP that can be used to run the tests.
+Once you have SSH'd onto the VM, we have a Docker container, provisioned with perfDHCP that can be used to run the tests.
 
 Run:
 ```bash

--- a/README.md
+++ b/README.md
@@ -60,32 +60,53 @@ Azure AD provides our authorization backend and is not provisioned through CLI/T
 We do remote testing of the DHCP service from a virtual machine running in Corsham.
 To access this VM you need to go through the bastion set up in production, which is on the same network (via the Transit Gateway) as the VM.
 
-The credentials below for the SSH key, IP address and password are kept in SSM parameter store in production.
+Follow the steps below to run the tests:
 
-### Bastion details:
+### SSH onto the bastion server
 
-SSH key - `/corsham/testing/bastion/private_key`
+1. Log into the production AWS console, and go to the SSM Parameter Store.
 
-Once you have SSH'd onto the Bastion, run:
+2. Copy the contents of the SSH key kept under `/corsham/testing/bastion/private_key` and save it to a local file corsham_test.pem
+
+3. Change the permission of the pem file by running: 
 
 ```bash
-ssh root@<VM_IP_ADDRESS>
+chmod 600 corsham_test.pem
 ```
 
-### VM details:
+4. Copy the IP address of the bastion server found under `/corsham/testing/bastion/ip` (refered to as <BASTION_IP> below)
 
-IP address - `/corsham/testing/vm/ip_address`
+5. SSH onto the bastion server:
 
-Password - `/corsham/testing/vm/password`
-
-Once you have SSH'd onto the VM, we have a Docker container, provisioned with perfDHCP that can be used to run the tests.
-
-Run:
 ```bash
-cd ~/smoke_test
+ssh -i corsham_test.pem ubuntu@<BASTION_IP>
+```
+
+### SSH onto the Corsham VM from the bastion server
+
+6. Copy the IP address for the VM found under `/corsham/testing/vm/ip_address` in SSM  (referred to as <VM_IP> below)
+
+7. Copy the SSH password for the VM found under `/corsham/testing/vm/password` in SSM (referred to as <VM_PASSWORD> below)
+
+8. SSH onto the Corsham VM:
+
+```bash
+ssh root@<VM_IP>
+```
+
+9. When prompted for the password enter <VM_PASSWORD>
+
+### Run the docker container
+
+There is a Dockerfile on the VM, based on the Dockerfile used for the DHCP KEA server itself.
+It is already configured to point to the production DHCP Network Load Balancer.
+
+10. Build and run the container
+
+```bash
+cd ~/
 docker build --network host -t test .
 docker run --network host -t test
 ```
 
-This will run perfDHCP against the production DHCP Network load balancers.
-The output will display the test results.
+The results of the test will display when perfdhcp has completed.

--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,23 @@ module "dns" {
   }
 }
 
+module "corsham_test_bastion" {
+  source  = "./modules/corsham_test"
+  subnets = module.vpc.public_subnets
+  vpc_id  = module.vpc.vpc_id
+  tags    = module.dhcp_label.tags
+
+  depends_on = [
+    module.vpc
+  ]
+
+  providers = {
+    aws = aws.env
+  }
+
+  count = terraform.workspace == "production" ? 1 : 0
+}
+
 module "dns_label" {
   source  = "cloudposse/label/null"
   version = "0.19.2"

--- a/main.tf
+++ b/main.tf
@@ -203,7 +203,7 @@ module "corsham_test_bastion" {
     aws = aws.env
   }
 
-  count = terraform.workspace == "em" ? 1 : 0
+  count = terraform.workspace == "production" ? 1 : 0
 }
 
 module "dns_label" {

--- a/main.tf
+++ b/main.tf
@@ -203,7 +203,7 @@ module "corsham_test_bastion" {
     aws = aws.env
   }
 
-  count = terraform.workspace == "production" ? 1 : 0
+  count = terraform.workspace == "em" ? 1 : 0
 }
 
 module "dns_label" {

--- a/modules/corsham_test/bastion.tf
+++ b/modules/corsham_test/bastion.tf
@@ -1,0 +1,52 @@
+resource "aws_instance" "corsham_testing_bastion" {
+  ami             = data.aws_ami.ubuntu.id
+  instance_type   = "t2.nano"
+  security_groups = [
+    aws_security_group.corsham_test_bastion.id
+  ]
+
+  subnet_id  = var.subnets[0]
+  key_name   = aws_key_pair.testing_bastion_public_key_pair.key_name
+  monitoring = true
+
+  instance_initiated_shutdown_behavior = "terminate"
+
+  tags = {
+    Name = "Corsham Test Bastion"
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "tls_private_key" "ec2" {
+  algorithm = "RSA"
+}
+
+resource "aws_key_pair" "testing_bastion_public_key_pair" {
+  key_name   = "corsham-bastion"
+  public_key = tls_private_key.ec2.public_key_openssh
+  tags       = var.tags
+}
+
+resource "aws_ssm_parameter" "instance_private_key" {
+  name        = "/corsham/testing/bastion/private_key"
+  type        = "SecureString"
+  value       = tls_private_key.ec2.private_key_pem
+  overwrite   = true
+  description = "SSH key for Corsham jumpbox"
+  tags        = var.tags
+}

--- a/modules/corsham_test/bastion.tf
+++ b/modules/corsham_test/bastion.tf
@@ -1,7 +1,8 @@
 resource "aws_instance" "corsham_testing_bastion" {
   ami             = data.aws_ami.ubuntu.id
   instance_type   = "t2.nano"
-  security_groups = [
+
+  vpc_security_group_ids = [
     aws_security_group.corsham_test_bastion.id
   ]
 
@@ -30,23 +31,4 @@ data "aws_ami" "ubuntu" {
   }
 
   owners = ["099720109477"] # Canonical
-}
-
-resource "tls_private_key" "ec2" {
-  algorithm = "RSA"
-}
-
-resource "aws_key_pair" "testing_bastion_public_key_pair" {
-  key_name   = "corsham-bastion"
-  public_key = tls_private_key.ec2.public_key_openssh
-  tags       = var.tags
-}
-
-resource "aws_ssm_parameter" "instance_private_key" {
-  name        = "/corsham/testing/bastion/private_key"
-  type        = "SecureString"
-  value       = tls_private_key.ec2.private_key_pem
-  overwrite   = true
-  description = "SSH key for Corsham jumpbox"
-  tags        = var.tags
 }

--- a/modules/corsham_test/security_groups.tf
+++ b/modules/corsham_test/security_groups.tf
@@ -1,0 +1,20 @@
+
+resource "aws_security_group" "corsham_test_bastion" {
+  name        = "corsham-test-bastion"
+  description = "Allow SSH into Corsham test bastion"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/modules/corsham_test/ssh.tf
+++ b/modules/corsham_test/ssh.tf
@@ -1,0 +1,9 @@
+resource "tls_private_key" "ec2" {
+  algorithm = "RSA"
+}
+
+resource "aws_key_pair" "testing_bastion_public_key_pair" {
+  key_name   = "corsham-bastion"
+  public_key = tls_private_key.ec2.public_key_openssh
+  tags       = var.tags
+}

--- a/modules/corsham_test/ssm.tf
+++ b/modules/corsham_test/ssm.tf
@@ -1,0 +1,17 @@
+resource "aws_ssm_parameter" "instance_private_key" {
+  name        = "/corsham/testing/bastion/private_key"
+  type        = "SecureString"
+  value       = tls_private_key.ec2.private_key_pem
+  overwrite   = true
+  description = "SSH key for Corsham jumpbox"
+  tags        = var.tags
+}
+
+resource "aws_ssm_parameter" "bastion_instance_ip" {
+  name        = "/corsham/testing/bastion/ip"
+  type        = "SecureString"
+  value       = aws_instance.corsham_testing_bastion.public_ip
+  overwrite   = true
+  description = "IP address of the Bastion server"
+  tags        = var.tags
+}

--- a/modules/corsham_test/variables.tf
+++ b/modules/corsham_test/variables.tf
@@ -1,0 +1,11 @@
+variable "subnets" {
+  type = list(string)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}


### PR DESCRIPTION
This creates an instance in production that is used as a jump box to get onto the VM in Corsham.

Once on the VM, tests can be run using perfDHCP on the production DHCP load balancers.
Documented in the README.
