### PR TITLE
Add code formatting github action

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  format-code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: ministryofjustice/github-actions/code-formatter@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What

Adds a github action to format code 

# Why 

So that any changes that were not formatted correctly are caught in the PR

# Notes

Uses the Ministry of Justice code formatter