### PR TITLE
Allow ECS to encrypt and decrypt objects stored in S3

### DIFF
--- a/modules/admin/iam-roles.tf
+++ b/modules/admin/iam-roles.tf
@@ -20,7 +20,8 @@ resource "aws_iam_role_policy" "ecs_admin_instance_policy" {
         "ecr:GetAuthorizationToken",
         "ecr:BatchCheckLayerAvailability",
         "ecr:GetDownloadUrlForLayer",
-        "ecr:BatchGetImage"
+        "ecr:BatchGetImage",
+        "kms:GenerateDataKey"
       ],
       "Resource": [ "*" ]
     },

--- a/modules/dns_dhcp_common/iam.tf
+++ b/modules/dns_dhcp_common/iam.tf
@@ -99,7 +99,8 @@ resource "aws_iam_role_policy" "ecs_service_policy" {
        "ec2:AuthorizeSecurityGroupIngress",
        "ec2:Describe*",
        "rds:*",
-       "ecr:*"
+       "ecr:*",
+       "kms:GenerateDataKey"
       ],
       "Resource": "*"
     }, {


### PR DESCRIPTION
Currently an error on ECS, unable to deal with the custom kms encryption