### PR TITLE
Ensure KEA can manage the lease database

### DIFF
--- a/modules/dhcp/mysql.tf
+++ b/modules/dhcp/mysql.tf
@@ -35,3 +35,10 @@ resource "aws_db_subnet_group" "db" {
 
   tags = var.tags
 }
+
+resource "mysql_grant" "kea" {
+  user       = aws_db_instance.dhcp_server_db.username
+  host       = aws_db_instance.dhcp_server_db.address
+  database   = aws_db_instance.dhcp_server_db.name
+  privileges = ["ALL"]
+}


### PR DESCRIPTION
KEA needs sufficient priviledges to use the lease database:
https://kea.readthedocs.io/en/kea-1.6.3/arm/admin.html

According to the documentation, you need to have "ALL" grant
priviledges.

This is to adress a current failure we are saying with the error message
of:
"ERROR/kea-admin: Create failed, the user, dhcpuser, has insufficient privileges.
 ERROR/kea-admin: mysql_can_create cannot trigger, check user permissions, mysql status = 1"