### PR TITLE
Change VPC default to not assign public IPs to EC2

### DIFF
--- a/modules/corsham_test/bastion.tf
+++ b/modules/corsham_test/bastion.tf
@@ -6,9 +6,9 @@ resource "aws_instance" "corsham_testing_bastion" {
     aws_security_group.corsham_test_bastion.id
   ]
 
-  subnet_id  = var.subnets[0]
-  key_name   = aws_key_pair.testing_bastion_public_key_pair.key_name
-  monitoring = true
+  subnet_id                   = var.subnets[0]
+  key_name                    = aws_key_pair.testing_bastion_public_key_pair.key_name
+  monitoring                  = true
   associate_public_ip_address = true
 
   instance_initiated_shutdown_behavior = "terminate"

--- a/modules/corsham_test/bastion.tf
+++ b/modules/corsham_test/bastion.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "corsham_testing_bastion" {
   subnet_id  = var.subnets[0]
   key_name   = aws_key_pair.testing_bastion_public_key_pair.key_name
   monitoring = true
+  associate_public_ip_address = true
 
   instance_initiated_shutdown_behavior = "terminate"
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -3,10 +3,10 @@ module "vpc" {
   version = "2.50.0"
   name    = var.prefix
 
-  cidr                 = var.cidr_block
-  enable_nat_gateway   = true
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  cidr                    = var.cidr_block
+  enable_nat_gateway      = true
+  enable_dns_hostnames    = true
+  enable_dns_support      = true
   map_public_ip_on_launch = false
 
   azs = [

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -7,6 +7,7 @@ module "vpc" {
   enable_nat_gateway   = true
   enable_dns_hostnames = true
   enable_dns_support   = true
+  map_public_ip_on_launch = false
 
   azs = [
     "${var.region}a",


### PR DESCRIPTION
A bug in Terraform ignores `associate_public_ip_address` on a launch
configuration, and inherits this attribute from the public subnet:
https://github.com/terraform-providers/terraform-provider-aws/issues/227

Change the defaults on the VPC to not assign any public IPs and
explicitly set one on the Corsham test bastion instance.