### PR TITLE
Add security groups to allow admin to access the database

### DIFF
--- a/modules/admin/security_groups.tf
+++ b/modules/admin/security_groups.tf
@@ -63,7 +63,6 @@ resource "aws_security_group" "admin_ecs" {
 
   tags = var.tags
 }
-
 resource "aws_security_group_rule" "admin_ecs_in" {
   type                     = "ingress"
   from_port                = 3000
@@ -71,4 +70,14 @@ resource "aws_security_group_rule" "admin_ecs_in" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.admin_ecs.id
   source_security_group_id = aws_security_group.admin_alb.id
+}
+
+resource "aws_security_group_rule" "admin_ecs_out_to_db" {
+  description              = "Allow access from admin app containers to admin database"
+  type                     = "egress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.admin_ecs.id
+  source_security_group_id = aws_security_group.admin_db.id
 }

--- a/modules/admin/security_groups.tf
+++ b/modules/admin/security_groups.tf
@@ -11,13 +11,13 @@ resource "aws_security_group" "admin_alb" {
 }
 
 resource "aws_security_group_rule" "admin_alb_in_from_web" {
-  description              = "Allow HTTPS traffic to the admin load balancer from the web"
-  type                     = "ingress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.admin_alb.id
-  cidr_blocks              = ["0.0.0.0/0"]
+  description       = "Allow HTTPS traffic to the admin load balancer from the web"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.admin_alb.id
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "admin_alb_out" {
@@ -82,12 +82,12 @@ resource "aws_security_group_rule" "admin_ecs_out_to_db" {
 }
 
 resource "aws_security_group_rule" "admin_ecs_out_to_web" {
-  description              = "Allow HTTPS access from admin app containers to the web"
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.admin_ecs.id
-  cidr_blocks              = ["0.0.0.0/0"]
+  description       = "Allow HTTPS access from admin app containers to the web"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.admin_ecs.id
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 


### PR DESCRIPTION
This has breaking changes to production like infrastructures. There are material changes to existing security groups and so these will require deleting before terraform will run