### PR TITLE
Move security group rules to their own resources

### DIFF
--- a/modules/dhcp/security_groups.tf
+++ b/modules/dhcp/security_groups.tf
@@ -7,33 +7,33 @@ resource "aws_security_group" "dhcp_server" {
 }
 
 resource "aws_security_group_rule" "dhcp_container_healthcheck_in" {
-  description              = "Allow health checks from the Load Balancer"
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.dhcp_server.id
-  cidr_blocks              = [var.vpc_cidr]
+  description       = "Allow health checks from the Load Balancer"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dhcp_server.id
+  cidr_blocks       = [var.vpc_cidr]
 }
 
 resource "aws_security_group_rule" "dhcp_container_udp_in" {
-  description              = "Allow inbound traffic to the KEA server"
-  type                     = "ingress"
-  from_port                = 67
-  to_port                  = 67
-  protocol                 = "udp"
-  security_group_id        = aws_security_group.dhcp_server.id
-  cidr_blocks              = [var.vpc_cidr]
+  description       = "Allow inbound traffic to the KEA server"
+  type              = "ingress"
+  from_port         = 67
+  to_port           = 67
+  protocol          = "udp"
+  security_group_id = aws_security_group.dhcp_server.id
+  cidr_blocks       = [var.vpc_cidr]
 }
 
 resource "aws_security_group_rule" "dhcp_container_web_out" {
-  description              = "Allow SSL outbound connections from the container"
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.dhcp_server.id
-  cidr_blocks              = ["0.0.0.0/0"]
+  description       = "Allow SSL outbound connections from the container"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dhcp_server.id
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 

--- a/modules/dns/security_groups.tf
+++ b/modules/dns/security_groups.tf
@@ -3,30 +3,35 @@ resource "aws_security_group" "dns_server" {
   description = "Allow the ECS agent to talk to the ECS endpoints"
   vpc_id      = var.vpc_id
 
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port   = 53
-    to_port     = 53
-    protocol    = "udp"
-    cidr_blocks = [var.vpc_cidr]
-  }
-
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = [var.vpc_cidr]
-  }
-
   tags = var.tags
+}
 
-  lifecycle {
-    create_before_destroy = true
-  }
+resource "aws_security_group_rule" "dns_container_web_out" {
+  description              = "Allow SSL outbound connections from the container"
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.dns_server.id
+  cidr_blocks              = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "dns_container_udp_in" {
+  description              = "Allow inbound traffic to the BIND server"
+  type                     = "ingress"
+  from_port                = 53
+  to_port                  = 53
+  protocol                 = "udp"
+  security_group_id        = aws_security_group.dns_server.id
+  cidr_blocks              = [var.vpc_cidr]
+}
+
+resource "aws_security_group_rule" "dns_container_healthcheck_in" {
+  description              = "Allow health checks from the Load Balancer"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.dns_server.id
+  cidr_blocks              = [var.vpc_cidr]
 }

--- a/modules/dns/security_groups.tf
+++ b/modules/dns/security_groups.tf
@@ -7,31 +7,31 @@ resource "aws_security_group" "dns_server" {
 }
 
 resource "aws_security_group_rule" "dns_container_web_out" {
-  description              = "Allow SSL outbound connections from the container"
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.dns_server.id
-  cidr_blocks              = ["0.0.0.0/0"]
+  description       = "Allow SSL outbound connections from the container"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dns_server.id
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "dns_container_udp_in" {
-  description              = "Allow inbound traffic to the BIND server"
-  type                     = "ingress"
-  from_port                = 53
-  to_port                  = 53
-  protocol                 = "udp"
-  security_group_id        = aws_security_group.dns_server.id
-  cidr_blocks              = [var.vpc_cidr]
+  description       = "Allow inbound traffic to the BIND server"
+  type              = "ingress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  security_group_id = aws_security_group.dns_server.id
+  cidr_blocks       = [var.vpc_cidr]
 }
 
 resource "aws_security_group_rule" "dns_container_healthcheck_in" {
-  description              = "Allow health checks from the Load Balancer"
-  type                     = "ingress"
-  from_port                = 80
-  to_port                  = 80
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.dns_server.id
-  cidr_blocks              = [var.vpc_cidr]
+  description       = "Allow health checks from the Load Balancer"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dns_server.id
+  cidr_blocks       = [var.vpc_cidr]
 }


### PR DESCRIPTION
    Terraform will try to destroy and recreate security groups with any material
    change to inline rules. Pulling the rules out from the group means they can be
    swapped out easily without having to drop environments or manually deleting
    security groups.