### PR TITLE
Expose both UDP and TCP on the target group

### DIFF
--- a/modules/dns_dhcp_common/load_balancer.tf
+++ b/modules/dns_dhcp_common/load_balancer.tf
@@ -25,7 +25,7 @@ resource "aws_lb" "load_balancer" {
 
 resource "aws_lb_target_group" "target_group" {
   name                 = var.prefix
-  protocol             = "UDP"
+  protocol             = "TCP_UDP"
   vpc_id               = var.vpc_id
   port                 = var.container_port
   target_type          = "ip"


### PR DESCRIPTION
This is required for health checks and normal traffic