### PR TITLE
Remove active health check on target group

### DIFF
--- a/modules/dns_dhcp_common/load_balancer.tf
+++ b/modules/dns_dhcp_common/load_balancer.tf
@@ -30,14 +30,6 @@ resource "aws_lb_target_group" "target_group" {
   port                 = var.container_port
   target_type          = "ip"
   deregistration_delay = 10
-
-  health_check {
-    protocol = "TCP"
-    port     = 80
-    interval = 10
-    healthy_threshold = 2
-    unhealthy_threshold = 2
-  }
 }
 
 resource "aws_lb_listener" "udp" {


### PR DESCRIPTION
We have implemented sophisticated KEA perfdhcp health checks and don't
use this health check as validation that the node is healthy.

This NLB health check takes around a minute to finish and even though
ECS reports that the server is up, it still needs to wait for this
health checks to complete before being added to the load balancer.

By removing this health check, we still get a required passive health check
before target is considered healthy.