### PR TITLE
Make production bastion a temporary piece of infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,23 @@ Azure AD provides our authorization backend and is not provisioned through CLI/T
 ## Corsham Test site
 
 We do remote testing of the DHCP service from a virtual machine running in Corsham.
+
+These tests run on an infinite loop, sending a total of 50 requests at a rate of 2 requests per second, emulating 2 concurrent connections with `perfdhcp`.
 To access this VM you need to go through the bastion set up in production, which is on the same network (via the Transit Gateway) as the VM.
 
-Follow the steps below to run the tests:
+Follow the steps below to gain access to the VM for debugging:
+
+### Create the Corsham VM bastion (jump box)
+
+This should only be used to get access to the VM and should not be left running in production.
+
+This is integrated with the production MoJ network so will only work on our production AWS account.
+
+1. Modify the `enable_corsham_test_bastion` variable in ./variables.tf and set it to true.
+
+2. Commit this to the `main` git branch and push it up.
+
+3. Ensure CI has created this instance.
 
 ### SSH onto the bastion server
 

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ module "corsham_test_bastion" {
     aws = aws.env
   }
 
-  count = terraform.workspace == "production" ? 1 : 0
+  count = terraform.workspace == "production" && var.enable_corsham_test_bastion == true ? 1 : 0
 }
 
 module "dns_label" {

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,6 @@ variable "dns_load_balancer_private_ip_eu_west_2c" {
 }
 
 variable "enable_corsham_test_bastion" {
-  type = bool
+  type    = bool
   default = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -100,3 +100,8 @@ variable "dns_load_balancer_private_ip_eu_west_2b" {
 variable "dns_load_balancer_private_ip_eu_west_2c" {
   type = string
 }
+
+variable "enable_corsham_test_bastion" {
+  type = bool
+  default = true
+}


### PR DESCRIPTION
This bastion server should only exist when access is needed to access the VMs
in Corsham. This improves the security posture of the DHCP service.

Tests in Corsham are now automated and run on an infinite loop, so no
need to run manually.

Only for debugging the remote VM would we spin up a bastion.

Currently this is setting to create this instance is set to true for testing.

A future commit will remove this.