### PR TITLE
Refactor Admin IAM policies

### DIFF
--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -54,8 +54,8 @@ EOF
 resource "aws_ecs_task_definition" "admin_task" {
   family                   = "${var.prefix}-task"
   requires_compatibilities = ["FARGATE"]
-  task_role_arn            = aws_iam_role.ecs_admin_instance_role.arn
-  execution_role_arn       = aws_iam_role.ecsTaskExecutionRole.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+  execution_role_arn       = aws_iam_role.ecs_execution_role.arn
   cpu                      = "512"
   memory                   = "1024"
   network_mode             = "awsvpc"


### PR DESCRIPTION
There are two roles that need to be assumed by ECS:
1. Task Execution role
2. Task role (application)

The execution role relies on a predefined AWS IAM role to allow it to
pull from ECR and write to CloudWatch.

The task role needs to access the ECS Service for DHCP to do a rolling
deployment. It also needs access to S3 to write the config files.