### PR TITLE
Output Admin ECS Service and Cluster name

### DIFF
--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -5,3 +5,10 @@ output "admin_db_identifier" {
 output "admin_url" {
   value = aws_route53_record.admin_app.fqdn
 }
+
+output "ecs" {
+  value = {
+    cluster_name = aws_ecs_cluster.admin_cluster.name
+    service_name = aws_ecs_service.admin-service.name
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,11 @@ output "terraform_outputs" {
       ecs = module.dhcp.ecs
       ecr = module.dhcp.ecr
     }
+
+    admin = {
+      ecs = module.admin.ecs
+    }
+
     authentication = {
       cognito = {
         identifier_urn = module.authentication.cognito_identifier_urn


### PR DESCRIPTION
This will be referenced by the Admin Rails deploy script to do a zero
downtime deployment of the admin service.