### PR TITLE
Add DHCP DB vars to Admin task definition

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -153,6 +153,7 @@ module "admin" {
   bind_config_bucket_key_arn           = module.dns.bind_config_bucket_key_arn
   dhcp_config_bucket_key_arn           = module.dhcp.dhcp_config_bucket_key_arn
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
+  dhcp_db_username                     = var.dhcp_db_username
 
   depends_on = [
     module.admin_vpc

--- a/main.tf
+++ b/main.tf
@@ -156,6 +156,7 @@ module "admin" {
   dhcp_db_username                     = var.dhcp_db_username
   dhcp_db_password                     = var.dhcp_db_password
   dhcp_db_name                         = module.dhcp.db_name
+  dhcp_db_host                         = module.dhcp.db_host
 
   depends_on = [
     module.admin_vpc

--- a/main.tf
+++ b/main.tf
@@ -155,6 +155,7 @@ module "admin" {
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
   dhcp_db_username                     = var.dhcp_db_username
   dhcp_db_password                     = var.dhcp_db_password
+  dhcp_db_name                         = module.dhcp.db_name
 
   depends_on = [
     module.admin_vpc

--- a/main.tf
+++ b/main.tf
@@ -157,6 +157,7 @@ module "admin" {
   dhcp_db_password                     = var.dhcp_db_password
   dhcp_db_name                         = module.dhcp.db_name
   dhcp_db_host                         = module.dhcp.db_host
+  dhcp_db_port                         = module.dhcp.db_port
 
   depends_on = [
     module.admin_vpc

--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,7 @@ module "admin" {
   dhcp_config_bucket_key_arn           = module.dhcp.dhcp_config_bucket_key_arn
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
   dhcp_db_username                     = var.dhcp_db_username
+  dhcp_db_password                     = var.dhcp_db_password
 
   depends_on = [
     module.admin_vpc

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -151,6 +151,10 @@ resource "aws_ecs_task_definition" "admin_task" {
         {
           "name": "DHCP_DB_NAME",
           "value": "${var.dhcp_db_name}"
+        },
+        {
+          "name": "DHCP_DB_HOST",
+          "value": "${var.dhcp_db_host}"
         }
       ],
       "image": "${aws_ecr_repository.admin_ecr.repository_url}",

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -155,6 +155,10 @@ resource "aws_ecs_task_definition" "admin_task" {
         {
           "name": "DHCP_DB_HOST",
           "value": "${var.dhcp_db_host}"
+        },
+        {
+          "name": "DHCP_DB_PORT",
+          "value": "${var.dhcp_db_port}"
         }
       ],
       "image": "${aws_ecr_repository.admin_ecr.repository_url}",

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -147,6 +147,10 @@ resource "aws_ecs_task_definition" "admin_task" {
         {
           "name": "DHCP_DB_PASS",
           "value": "${var.dhcp_db_password}"
+        },
+        {
+          "name": "DHCP_DB_NAME",
+          "value": "${var.dhcp_db_name}"
         }
       ],
       "image": "${aws_ecr_repository.admin_ecr.repository_url}",

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -143,6 +143,10 @@ resource "aws_ecs_task_definition" "admin_task" {
         {
           "name": "DHCP_DB_USER",
           "value": "${var.dhcp_db_username}"
+        },
+        {
+          "name": "DHCP_DB_PASS",
+          "value": "${var.dhcp_db_password}"
         }
       ],
       "image": "${aws_ecr_repository.admin_ecr.repository_url}",

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -139,6 +139,10 @@ resource "aws_ecs_task_definition" "admin_task" {
         },{
           "name": "BIND_CONFIG_BUCKET",
           "value": "${var.bind_config_bucket_name}"
+        },
+        {
+          "name": "DHCP_DB_USER",
+          "value": "${var.dhcp_db_username}"
         }
       ],
       "image": "${aws_ecr_repository.admin_ecr.repository_url}",

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -128,3 +128,7 @@ variable "dhcp_db_name" {
 variable "dhcp_db_host" {
   type = string
 }
+
+variable "dhcp_db_port" {
+  type = string
+}

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -120,3 +120,7 @@ variable "dhcp_db_username" {
 variable "dhcp_db_password" {
   type = string
 }
+
+variable "dhcp_db_name" {
+  type = string
+}

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -116,3 +116,7 @@ variable "admin_local_development_domain_affix" {
 variable "dhcp_db_username" {
   type = string
 }
+
+variable "dhcp_db_password" {
+  type = string
+}

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -112,3 +112,7 @@ variable "bind_config_bucket_key_arn" {
 variable "admin_local_development_domain_affix" {
   type = string
 }
+
+variable "dhcp_db_username" {
+  type = string
+}

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -124,3 +124,7 @@ variable "dhcp_db_password" {
 variable "dhcp_db_name" {
   type = string
 }
+
+variable "dhcp_db_host" {
+  type = string
+}

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -36,3 +36,7 @@ output "load_balancer" {
 output "dhcp_config_bucket_key_arn" {
   value = aws_kms_key.config_bucket_key.arn
 }
+
+output "db_name" {
+  value = aws_db_instance.dhcp_server_db.name
+}

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -44,3 +44,7 @@ output "db_name" {
 output "db_host" {
   value = aws_route53_record.dhcp_db.fqdn
 }
+
+output "db_port" {
+  value = aws_db_instance.dhcp_server_db.port
+}

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -40,3 +40,7 @@ output "dhcp_config_bucket_key_arn" {
 output "db_name" {
   value = aws_db_instance.dhcp_server_db.name
 }
+
+output "db_host" {
+  value = aws_route53_record.dhcp_db.fqdn
+}


### PR DESCRIPTION
Allows us to test connections from the admin portal to the DHCP DB