### PR TITLE
Only allow access to and from the bastion to known sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ This should only be used to get access to the VM and should not be left running 
 
 This is integrated with the production MoJ network so will only work on our production AWS account.
 
-1. Modify the `enable_corsham_test_bastion` variable in ./variables.tf and set it to true.
+1. Add your public IP address to SSM parameter store, `/staff-device/corsham_testing/bastion_allowed_ingress_ip`.
 
-2. Commit this to the `main` git branch and push it up.
+2. Modify the `enable_corsham_test_bastion` variable in ./variables.tf and set it to true.
 
-3. Ensure CI has created this instance.
+3. Commit this to the `main` git branch and push it up.
+
+4. Ensure CI has created this instance.
 
 ### SSH onto the bastion server
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,6 +30,8 @@ env:
     TF_VAR_dns_load_balancer_private_ip_eu_west_2b: "/staff-device/dns/$ENV/load_balancer_private_ip_eu_west_2b"
     TF_VAR_dns_load_balancer_private_ip_eu_west_2c: "/staff-device/dns/$ENV/load_balancer_private_ip_eu_west_2c"
     TF_VAR_sentry_dsn: "/staff-device/admin/sentry_dsn"
+    TF_VAR_bastion_allowed_ingress_ip: "/staff-device/corsham_testing/bastion_allowed_ingress_ip"
+    TF_VAR_bastion_allowed_egress_ip: "/staff-device/corsham_testing/bastion_allowed_egress_ip"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
 
 phases:

--- a/main.tf
+++ b/main.tf
@@ -219,10 +219,12 @@ module "dns" {
 }
 
 module "corsham_test_bastion" {
-  source  = "./modules/corsham_test"
-  subnets = module.vpc.public_subnets
-  vpc_id  = module.vpc.vpc_id
-  tags    = module.dhcp_label.tags
+  source                     = "./modules/corsham_test"
+  subnets                    = module.vpc.public_subnets
+  vpc_id                     = module.vpc.vpc_id
+  tags                       = module.dhcp_label.tags
+  bastion_allowed_ingress_ip = var.bastion_allowed_ingress_ip
+  corsham_allowed_egress_ip  = var.corsham_allowed_egress_ip
 
   depends_on = [
     module.vpc

--- a/modules/corsham_test/security_groups.tf
+++ b/modules/corsham_test/security_groups.tf
@@ -8,13 +8,13 @@ resource "aws_security_group" "corsham_test_bastion" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.corsham_allowed_egress_ip}/32"]
   }
 
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.bastion_allowed_ingress_ip}/32"]
   }
 }

--- a/modules/corsham_test/variables.tf
+++ b/modules/corsham_test/variables.tf
@@ -9,3 +9,11 @@ variable "vpc_id" {
 variable "tags" {
   type = map(string)
 }
+
+variable "bastion_allowed_ingress_ip" {
+  type = string
+}
+
+variable "corsham_allowed_egress_ip" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -117,11 +117,11 @@ variable "sentry_dsn" {
 }
 
 variable "bastion_allowed_ingress_ip" {
-  type = string
+  type    = string
   default = "noop"
 }
 
 variable "corsham_allowed_egress_ip" {
-  type = string
+  type    = string
   default = "noop"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -115,3 +115,13 @@ variable "sentry_dsn" {
   type    = string
   default = ""
 }
+
+variable "bastion_allowed_ingress_ip" {
+  type = string
+  default = "noop"
+}
+
+variable "corsham_allowed_egress_ip" {
+  type = string
+  default = "noop"
+}


### PR DESCRIPTION
This improves security if the bastion was spun up.