### PR TITLE
Allow connection from Admin app to the DHCP DB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,6 +113,7 @@ module "dhcp" {
   is_publicly_accessible                 = local.publicly_accessible
   vpc_cidr                               = local.dns_dhcp_vpc_cidr
   admin_local_development_domain_affix   = var.admin_local_development_domain_affix
+  admin_ecs_security_group_id            = module.admin.admin_ecs_security_group_id
 
   providers = {
     aws = aws.env

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,8 @@ module "dhcp" {
   }
 
   depends_on = [
-    module.vpc
+    module.vpc,
+    module.admin_dhcp_vpc_peering
   ]
 }
 
@@ -162,7 +163,8 @@ module "admin" {
   dhcp_db_in_security_group_id         = module.dhcp.dhcp_db_in_security_group_id
 
   depends_on = [
-    module.admin_vpc
+    module.admin_vpc,
+    module.admin_dhcp_vpc_peering
   ]
 
   providers = {
@@ -274,5 +276,16 @@ module "alarms_label" {
 
     "environment-name" = "global"
     "source-code"      = "https://github.com/ministryofjustice/staff-device-dns-dhcp-infrastructure"
+  }
+}
+
+module "admin_dhcp_vpc_peering" {
+  source = "./modules/vpc_peering"
+
+  source_vpc_id = module.admin_vpc.vpc_id
+  target_vpc_id = module.vpc.vpc_id
+
+  providers = {
+    aws = aws.env
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,7 @@ module "admin" {
   dhcp_db_name                         = module.dhcp.db_name
   dhcp_db_host                         = module.dhcp.db_host
   dhcp_db_port                         = module.dhcp.db_port
+  dhcp_db_in_security_group_id         = module.dhcp.dhcp_db_in_security_group_id
 
   depends_on = [
     module.admin_vpc

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -12,3 +12,7 @@ output "ecs" {
     service_name = aws_ecs_service.admin-service.name
   }
 }
+
+output "admin_ecs_security_group_id" {
+  value = aws_security_group.admin_ecs.id
+}

--- a/modules/admin/security_groups.tf
+++ b/modules/admin/security_groups.tf
@@ -91,3 +91,12 @@ resource "aws_security_group_rule" "admin_ecs_out_to_web" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
+resource "aws_security_group_rule" "admin_ecs_out_to_dhcp_db" {
+  description              = "Allow access from admin app containers to dhcp database"
+  type                     = "egress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.admin_ecs.id
+  source_security_group_id = var.dhcp_db_in_security_group_id
+}

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -132,3 +132,7 @@ variable "dhcp_db_host" {
 variable "dhcp_db_port" {
   type = string
 }
+
+variable "dhcp_db_in_security_group_id" {
+  type = string
+}

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -48,3 +48,7 @@ output "db_host" {
 output "db_port" {
   value = aws_db_instance.dhcp_server_db.port
 }
+
+output "dhcp_db_in_security_group_id" {
+  value = aws_security_group.dhcp_db_in.id
+}

--- a/modules/dhcp/security_groups.tf
+++ b/modules/dhcp/security_groups.tf
@@ -72,3 +72,13 @@ resource "aws_security_group_rule" "dhcp_db_in" {
   security_group_id        = aws_security_group.dhcp_db_in.id
   source_security_group_id = aws_security_group.dhcp_server.id
 }
+
+resource "aws_security_group_rule" "dhcp_db_in_from_admin_ecs" {
+  description              = "Allow access in to dhcp database from admin app containers"
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.dhcp_db_in.id
+  source_security_group_id = var.admin_ecs_security_group_id
+}

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -85,3 +85,7 @@ variable "is_publicly_accessible" {
 variable "admin_local_development_domain_affix" {
   type = string
 }
+
+variable "admin_ecs_security_group_id" {
+  type = string
+}

--- a/modules/vpc_peering/main.tf
+++ b/modules/vpc_peering/main.tf
@@ -1,4 +1,5 @@
 resource "aws_vpc_peering_connection" "vpc_peering_connection" {
-  vpc_id   = var.source_vpc_id
+  vpc_id      = var.source_vpc_id
   peer_vpc_id = var.target_vpc_id
+  auto_accept = true
 }

--- a/modules/vpc_peering/main.tf
+++ b/modules/vpc_peering/main.tf
@@ -1,0 +1,4 @@
+resource "aws_vpc_peering_connection" "vpc_peering_connection" {
+  vpc_id   = var.source_vpc_id
+  peer_vpc_id = var.target_vpc_id
+}

--- a/modules/vpc_peering/variables.tf
+++ b/modules/vpc_peering/variables.tf
@@ -1,0 +1,7 @@
+variable "source_vpc_id" {
+  type = string
+}
+
+variable "target_vpc_id" {
+  type = string
+}


### PR DESCRIPTION
Enables VPC peering between the two VPCs so that the security groups can be created across different networks