### PR TITLE
Add apply and destroy make commands that always use a new 2hour session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 init:
-	terraform init -reconfigure --backend-config="key=terraform.development.state"
+	aws-vault exec moj-pttp-shared-services -- terraform init -reconfigure --backend-config="key=terraform.development.state"
 
-.PHONY: init
+apply:
+	aws-vault clear && aws-vault exec moj-pttp-shared-services --duration=2h -- terraform apply
+
+destroy:
+	aws-vault clear && aws-vault exec moj-pttp-shared-services --duration=2h -- terraform destroy
+
+.PHONY: init apply destroy

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ Azure AD provides the authorization backend, via [AWS Cognito](https://aws.amazo
 
 ## Local Development
 
+[Install aws-vault](https://github.com/99designs/aws-vault#installing) and [add the MoJ shared services account](https://github.com/99designs/aws-vault#quick-start) as 'moj-pttp-shared-services'.
+
 Initialise the repo:
 
 ```shell
-  aws-vault exec moj-pttp-shared-services -- make init
+  make init
 ```
 
 Create your workspace
@@ -48,7 +50,7 @@ Select your workspace
 Select your workspace
 
 ```shell
-  aws-vault exec moj-pttp-shared-services -- terraform apply
+  make apply
 ```
 
 ## Corsham Test site
@@ -80,7 +82,7 @@ This is integrated with the production MoJ network so will only work on our prod
 
 2. Copy the contents of the SSH key kept under `/corsham/testing/bastion/private_key` and save it to a local file corsham_test.pem
 
-3. Change the permission of the pem file by running: 
+3. Change the permission of the pem file by running:
 
 ```bash
 chmod 600 corsham_test.pem


### PR DESCRIPTION
By clearing the sessions and using a 2 hour session, we ensure that the apply or destroy will never timeout part way through