### PR TITLE
Populate pDNS environment variables for admin container

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,7 @@ env:
     TF_VAR_enable_ssh_key_generation: false
   parameter-store:
     TF_VAR_assume_role: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
+    TF_VAR_pdns_ips: "/staff-device/dns/pdns/ips"
     TF_VAR_dhcp_db_username: "/codebuild/dhcp/$ENV/db/username"
     TF_VAR_dhcp_db_password: "/codebuild/dhcp/$ENV/db/password"
     TF_VAR_admin_db_username: "/codebuild/dhcp/$ENV/admin/db/username"

--- a/main.tf
+++ b/main.tf
@@ -160,6 +160,7 @@ module "admin" {
   dhcp_db_name                         = module.dhcp.db_name
   dhcp_db_host                         = module.dhcp.db_host
   dhcp_db_port                         = module.dhcp.db_port
+  pdns_ips                             = var.pdns_ips
 
   depends_on = [
     module.admin_vpc

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -166,6 +166,10 @@ resource "aws_ecs_task_definition" "admin_task" {
         {
           "name": "DHCP_DB_PORT",
           "value": "${var.dhcp_db_port}"
+        },
+        {
+          "name": "PDNS_IPS",
+          "value": "${var.pdns_ips}"
         }
       ],
       "image": "${aws_ecr_repository.admin_ecr.repository_url}",

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -140,3 +140,7 @@ variable "dhcp_db_host" {
 variable "dhcp_db_port" {
   type = string
 }
+
+variable "pdns_ips" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -125,3 +125,8 @@ variable "bastion_allowed_egress_ip" {
   type    = string
   default = "noop"
 }
+
+variable "pdns_ips" {
+  type = string
+  default = "[]"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,6 @@ variable "bastion_allowed_egress_ip" {
 }
 
 variable "pdns_ips" {
-  type = string
+  type    = string
   default = "[]"
 }


### PR DESCRIPTION
These IPs are stored in SSM and set as environment variables when the
container is booted. These values will be used to populate the fallback
zone in the BIND configuration.