### PR TITLE
Add proxy protocol v2 to DHCP target group

### DIFF
--- a/modules/dns_dhcp_common/load_balancer.tf
+++ b/modules/dns_dhcp_common/load_balancer.tf
@@ -30,6 +30,7 @@ resource "aws_lb_target_group" "target_group" {
   port                 = var.container_port
   target_type          = "ip"
   deregistration_delay = 10
+  proxy_protocol_v2    = true
 
   depends_on = [aws_lb.load_balancer]
 }


### PR DESCRIPTION
We want to preserve the client IP address as the source. This will
affect the distribution of load to the registered targets.