### PR TITLE
Add Transit Gateway as the default route for DHCP and DNS

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -51,6 +51,7 @@ phases:
       - terraform providers
       - terraform workspace new $ENV || true
       - terraform workspace select $ENV
+      - terraform destroy --auto-approve -no-color
       - terraform apply --auto-approve -no-color
       - ./scripts/publish_terraform_outputs
       - TEMP_ROLE=`aws sts assume-role --role-arn $ROLE_ARN --role-session-name ci-build-$CODEBUILD_BUILD_NUMBER`

--- a/main.tf
+++ b/main.tf
@@ -67,12 +67,12 @@ locals {
 }
 
 module "servers_vpc" {
-  source              = "./modules/servers_vpc"
-  prefix              = module.dhcp_label.id
-  region              = data.aws_region.current_region.id
-  cidr_block          = "10.180.80.0/22"
-  cidr_block_new_bits = 2
-  enable_nat_gateway  = true
+  source                           = "./modules/servers_vpc"
+  prefix                           = module.dhcp_label.id
+  region                           = data.aws_region.current_region.id
+  cidr_block                       = "10.180.80.0/22"
+  cidr_block_new_bits              = 2
+  enable_nat_gateway               = true
   rds_endpoint_private_dns_enabled = true
 
   providers = {
@@ -114,7 +114,7 @@ module "dhcp" {
   vpc_cidr                               = local.dns_dhcp_vpc_cidr
   admin_local_development_domain_affix   = var.admin_local_development_domain_affix
   dhcp_egress_transit_gateway_routes     = var.dhcp_egress_transit_gateway_routes
-  private_route_table_ids                 = module.servers_vpc.private_route_table_ids
+  private_route_table_ids                = module.servers_vpc.private_route_table_ids
 
   providers = {
     aws = aws.env

--- a/main.tf
+++ b/main.tf
@@ -66,12 +66,14 @@ locals {
   dns_dhcp_vpc_cidr = "10.180.80.0/22"
 }
 
-module "vpc" {
-  source              = "./modules/vpc"
+module "servers_vpc" {
+  source              = "./modules/servers_vpc"
   prefix              = module.dhcp_label.id
   region              = data.aws_region.current_region.id
   cidr_block          = "10.180.80.0/22"
   cidr_block_new_bits = 2
+  enable_nat_gateway  = true
+  rds_endpoint_private_dns_enabled = true
 
   providers = {
     aws = aws.env
@@ -92,19 +94,17 @@ module "admin_vpc" {
 module "dhcp" {
   source                                 = "./modules/dhcp"
   prefix                                 = module.dhcp_label.id
-  subnets                                = module.vpc.public_subnets
+  subnets                                = module.servers_vpc.private_subnets
   tags                                   = module.dhcp_label.tags
-  vpc_id                                 = module.vpc.vpc_id
+  vpc_id                                 = module.servers_vpc.vpc_id
   dhcp_db_password                       = var.dhcp_db_password
   dhcp_db_username                       = var.dhcp_db_username
-  public_subnet_cidr_blocks              = module.vpc.public_subnet_cidr_blocks
   env                                    = var.env
   dhcp_transit_gateway_id                = var.dhcp_transit_gateway_id
   enable_dhcp_transit_gateway_attachment = var.enable_dhcp_transit_gateway_attachment
   transit_gateway_route_table_id         = var.transit_gateway_route_table_id
   load_balancer_private_ip_eu_west_2a    = var.dhcp_load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b    = var.dhcp_load_balancer_private_ip_eu_west_2b
-  load_balancer_private_ip_eu_west_2c    = var.dhcp_load_balancer_private_ip_eu_west_2c
   critical_notifications_arn             = module.alarms.critical_notifications_arn
   vpn_hosted_zone_id                     = var.vpn_hosted_zone_id
   vpn_hosted_zone_domain                 = var.vpn_hosted_zone_domain
@@ -114,14 +114,14 @@ module "dhcp" {
   vpc_cidr                               = local.dns_dhcp_vpc_cidr
   admin_local_development_domain_affix   = var.admin_local_development_domain_affix
   dhcp_egress_transit_gateway_routes     = var.dhcp_egress_transit_gateway_routes
-  public_route_table_ids                 = module.vpc.public_route_table_ids
+  private_route_table_ids                 = module.servers_vpc.private_route_table_ids
 
   providers = {
     aws = aws.env
   }
 
   depends_on = [
-    module.vpc
+    module.servers_vpc
   ]
 }
 
@@ -206,17 +206,16 @@ module "alarms" {
 module "dns" {
   source                              = "./modules/dns"
   prefix                              = module.dns_label.id
-  subnets                             = module.vpc.public_subnets
+  subnets                             = module.servers_vpc.private_subnets
   tags                                = module.dns_label.tags
   critical_notifications_arn          = module.alarms.critical_notifications_arn
   load_balancer_private_ip_eu_west_2a = var.dns_load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b = var.dns_load_balancer_private_ip_eu_west_2b
-  load_balancer_private_ip_eu_west_2c = var.dns_load_balancer_private_ip_eu_west_2c
-  vpc_id                              = module.vpc.vpc_id
+  vpc_id                              = module.servers_vpc.vpc_id
   vpc_cidr                            = local.dns_dhcp_vpc_cidr
 
   depends_on = [
-    module.vpc
+    module.servers_vpc
   ]
 
   providers = {
@@ -226,14 +225,14 @@ module "dns" {
 
 module "corsham_test_bastion" {
   source                     = "./modules/corsham_test"
-  subnets                    = module.vpc.public_subnets
-  vpc_id                     = module.vpc.vpc_id
+  subnets                    = module.servers_vpc.public_subnets
+  vpc_id                     = module.servers_vpc.vpc_id
   tags                       = module.dhcp_label.tags
   bastion_allowed_ingress_ip = var.bastion_allowed_ingress_ip
   bastion_allowed_egress_ip  = var.bastion_allowed_egress_ip
 
   depends_on = [
-    module.vpc
+    module.servers_vpc
   ]
 
   providers = {
@@ -288,7 +287,7 @@ module "dhcp_dns_vpc_flow_logs" {
   prefix = "staff-device-dns-dhcp-${terraform.workspace}"
   region = data.aws_region.current_region.id
   tags   = module.dhcp_label.tags
-  vpc_id = module.vpc.vpc_id
+  vpc_id = module.servers_vpc.vpc_id
 
   providers = {
     aws = aws.env

--- a/modules/dhcp/egress_transit_gateway_routes.tf
+++ b/modules/dhcp/egress_transit_gateway_routes.tf
@@ -1,7 +1,7 @@
-resource "aws_route" "egress_routes" {
-  for_each = var.enable_dhcp_transit_gateway_attachment ? var.public_route_table_ids : []
+resource "aws_route" "transit_gateway_default_route" {
+  for_each = var.enable_dhcp_transit_gateway_attachment ? var.private_route_table_ids : []
 
   route_table_id         = each.value
-  destination_cidr_block = var.dhcp_egress_transit_gateway_routes[0]
+  destination_cidr_block = "0.0.0.0/0"
   transit_gateway_id     = var.dhcp_transit_gateway_id
 }

--- a/modules/dhcp/main.tf
+++ b/modules/dhcp/main.tf
@@ -10,8 +10,10 @@ module "dns_dhcp_common" {
   task_definition_arn                 = aws_ecs_task_definition.server_task.arn
   load_balancer_private_ip_eu_west_2a = var.load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b = var.load_balancer_private_ip_eu_west_2b
-  load_balancer_private_ip_eu_west_2c = var.load_balancer_private_ip_eu_west_2c
   critical_notifications_arn          = var.critical_notifications_arn
   api_lb_target_group_arn             = aws_lb_target_group.http_api_target_group.arn
   has_api_lb                          = true
+  desired_count                       = 1
+  max_capacity                        = 2
+  min_capacity                        = 1
 }

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -30,10 +30,6 @@ variable "dhcp_db_password" {
   type = string
 }
 
-variable "public_subnet_cidr_blocks" {
-  type = list(string)
-}
-
 variable "dhcp_transit_gateway_id" {
   type = string
 }
@@ -51,10 +47,6 @@ variable "load_balancer_private_ip_eu_west_2a" {
 }
 
 variable "load_balancer_private_ip_eu_west_2b" {
-  type = string
-}
-
-variable "load_balancer_private_ip_eu_west_2c" {
   type = string
 }
 
@@ -90,6 +82,6 @@ variable "dhcp_egress_transit_gateway_routes" {
   type = list(string)
 }
 
-variable "public_route_table_ids" {
+variable "private_route_table_ids" {
   type = set(string)
 }

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -10,6 +10,9 @@ module "dns_dhcp_common" {
   task_definition_arn                 = aws_ecs_task_definition.server_task.arn
   load_balancer_private_ip_eu_west_2a = var.load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b = var.load_balancer_private_ip_eu_west_2b
-  load_balancer_private_ip_eu_west_2c = var.load_balancer_private_ip_eu_west_2c
   critical_notifications_arn          = var.critical_notifications_arn
+  desired_count                       = 2
+  max_capacity                        = 6
+  min_capacity                        = 2
+
 }

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -29,7 +29,3 @@ variable "load_balancer_private_ip_eu_west_2a" {
 variable "load_balancer_private_ip_eu_west_2b" {
   type = string
 }
-
-variable "load_balancer_private_ip_eu_west_2c" {
-  type = string
-}

--- a/modules/dns_dhcp_common/ecs.tf
+++ b/modules/dns_dhcp_common/ecs.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_service" "service" {
   name            = "${var.prefix}-service"
   cluster         = aws_ecs_cluster.server_cluster.id
   task_definition = var.task_definition_arn
-  desired_count   = "3"
+  desired_count   = var.desired_count
   launch_type     = "FARGATE"
 
   load_balancer {
@@ -38,10 +38,6 @@ resource "aws_ecs_service" "service" {
     ]
 
     assign_public_ip = true
-  }
-
-  lifecycle {
-    ignore_changes = [desired_count]
   }
 }
 

--- a/modules/dns_dhcp_common/ecs_auto_scaling.tf
+++ b/modules/dns_dhcp_common/ecs_auto_scaling.tf
@@ -1,8 +1,8 @@
 resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.server_cluster.name}/${aws_ecs_service.service.name}"
-  max_capacity       = 6
-  min_capacity       = 3
+  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity
   scalable_dimension = "ecs:service:DesiredCount"
 }
 

--- a/modules/dns_dhcp_common/load_balancer.tf
+++ b/modules/dns_dhcp_common/load_balancer.tf
@@ -13,11 +13,6 @@ resource "aws_lb" "load_balancer" {
     private_ipv4_address = var.load_balancer_private_ip_eu_west_2b
   }
 
-  subnet_mapping {
-    subnet_id            = var.subnets[2]
-    private_ipv4_address = var.load_balancer_private_ip_eu_west_2c
-  }
-
   enable_deletion_protection = false
 
   tags = var.tags
@@ -29,7 +24,7 @@ resource "aws_lb_target_group" "target_group" {
   vpc_id               = var.vpc_id
   port                 = var.container_port
   target_type          = "ip"
-  deregistration_delay = 10
+  deregistration_delay = 300
 
   depends_on = [aws_lb.load_balancer]
 }

--- a/modules/dns_dhcp_common/variables.tf
+++ b/modules/dns_dhcp_common/variables.tf
@@ -34,10 +34,6 @@ variable "load_balancer_private_ip_eu_west_2b" {
   type = string
 }
 
-variable "load_balancer_private_ip_eu_west_2c" {
-  type = string
-}
-
 variable "vpc_id" {
   type = string
 }
@@ -54,4 +50,16 @@ variable "has_api_lb" {
 variable "api_lb_target_group_arn" {
   type    = string
   default = ""
+}
+
+variable "desired_count" {
+  type    = number
+}
+
+variable "max_capacity" {
+  type    = number
+}
+
+variable "min_capacity" {
+  type    = number
 }

--- a/modules/dns_dhcp_common/variables.tf
+++ b/modules/dns_dhcp_common/variables.tf
@@ -53,13 +53,13 @@ variable "api_lb_target_group_arn" {
 }
 
 variable "desired_count" {
-  type    = number
+  type = number
 }
 
 variable "max_capacity" {
-  type    = number
+  type = number
 }
 
 variable "min_capacity" {
-  type    = number
+  type = number
 }

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -1,0 +1,33 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "2.50.0"
+  name    = var.prefix
+
+  cidr                 = var.cidr_block
+  enable_nat_gateway   = var.enable_nat_gateway
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  create_flow_log_cloudwatch_iam_role  = true
+  create_flow_log_cloudwatch_log_group = true
+  enable_flow_log                      = true
+
+  rds_endpoint_private_dns_enabled     = var.rds_endpoint_private_dns_enabled
+  rds_endpoint_security_group_ids      = []
+  enable_s3_endpoint                   = var.enable_s3_endpoint
+
+  azs = [
+    "${var.region}a",
+    "${var.region}b"
+  ]
+
+  private_subnets = [
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 0),
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 1)
+  ]
+
+  public_subnets = [
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3)
+  ]
+}

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -12,9 +12,9 @@ module "vpc" {
   create_flow_log_cloudwatch_log_group = true
   enable_flow_log                      = true
 
-  rds_endpoint_private_dns_enabled     = var.rds_endpoint_private_dns_enabled
-  rds_endpoint_security_group_ids      = []
-  enable_s3_endpoint                   = var.enable_s3_endpoint
+  rds_endpoint_private_dns_enabled = var.rds_endpoint_private_dns_enabled
+  rds_endpoint_security_group_ids  = []
+  enable_s3_endpoint               = var.enable_s3_endpoint
 
   azs = [
     "${var.region}a",

--- a/modules/servers_vpc/outputs.tf
+++ b/modules/servers_vpc/outputs.tf
@@ -1,0 +1,15 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
+output "private_route_table_ids" {
+  value = module.vpc.private_route_table_ids
+}

--- a/modules/servers_vpc/variables.tf
+++ b/modules/servers_vpc/variables.tf
@@ -1,0 +1,31 @@
+variable "cidr_block" {
+  type = string
+}
+
+variable "cidr_block_new_bits" {
+  type    = number
+  default = 8
+}
+
+variable "region" {
+  type = string
+}
+
+variable "prefix" {
+  type = string
+}
+
+variable "enable_nat_gateway" {
+  type = bool
+  default = false
+}
+
+variable "rds_endpoint_private_dns_enabled" {
+  type = bool
+  default = false
+}
+
+variable "enable_s3_endpoint" {
+  type = bool
+  default = false
+}

--- a/modules/servers_vpc/variables.tf
+++ b/modules/servers_vpc/variables.tf
@@ -16,16 +16,16 @@ variable "prefix" {
 }
 
 variable "enable_nat_gateway" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "rds_endpoint_private_dns_enabled" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "enable_s3_endpoint" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -14,13 +14,11 @@ module "vpc" {
 
   azs = [
     "${var.region}a",
-    "${var.region}b",
-    "${var.region}c"
+    "${var.region}b"
   ]
 
   public_subnets = [
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 1),
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),
-    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3)
+    cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2)
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,19 +85,11 @@ variable "dhcp_load_balancer_private_ip_eu_west_2b" {
   type = string
 }
 
-variable "dhcp_load_balancer_private_ip_eu_west_2c" {
-  type = string
-}
-
 variable "dns_load_balancer_private_ip_eu_west_2a" {
   type = string
 }
 
 variable "dns_load_balancer_private_ip_eu_west_2b" {
-  type = string
-}
-
-variable "dns_load_balancer_private_ip_eu_west_2c" {
   type = string
 }
 


### PR DESCRIPTION
Any unrouted requests need to go through to the transit gateway to
handle traffic from the network. DNS will get a NAT gateway in a future
pull request to add a known source IP to it that can be whitelisted.

Recalculate CIDR subnets and remove one of the 3 AZs, running in 2 is good enough.
Set task count for DHCP to 1 to prevent any concurrency issues when
traffic is high.

This requires a rebuild of all the infrastructure as you cannot modify
the network in place.