### PR TITLE
Move NAT gateways into public subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,8 @@ module "admin_vpc" {
 module "dhcp" {
   source                                 = "./modules/dhcp"
   prefix                                 = module.dhcp_label.id
-  subnets                                = module.servers_vpc.private_subnets
+  private_subnets                        = module.servers_vpc.private_subnets
+  public_subnets                         = module.servers_vpc.public_subnets
   tags                                   = module.dhcp_label.tags
   vpc_id                                 = module.servers_vpc.vpc_id
   dhcp_db_password                       = var.dhcp_db_password

--- a/modules/dhcp/http_api_load_balancer.tf
+++ b/modules/dhcp/http_api_load_balancer.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "http_api_load_balancer" {
   name               = "${var.short_prefix}-dhcp-api"
   load_balancer_type = "network"
   internal           = true
-  subnets            = var.subnets
+  subnets            = var.private_subnets
 
   enable_deletion_protection = false
 

--- a/modules/dhcp/main.tf
+++ b/modules/dhcp/main.tf
@@ -2,7 +2,7 @@ module "dns_dhcp_common" {
   source                              = "../dns_dhcp_common"
   prefix                              = var.prefix
   tags                                = var.tags
-  subnets                             = var.subnets
+  subnets                             = var.private_subnets
   vpc_id                              = var.vpc_id
   security_group_id                   = aws_security_group.dhcp_server.id
   container_port                      = "67"

--- a/modules/dhcp/mysql.tf
+++ b/modules/dhcp/mysql.tf
@@ -31,7 +31,7 @@ resource "aws_db_instance" "dhcp_server_db" {
 
 resource "aws_db_subnet_group" "db" {
   name       = "${var.prefix}-main"
-  subnet_ids = var.subnets
+  subnet_ids = var.private_subnets
 
   tags = var.tags
 }

--- a/modules/dhcp/routing.tf
+++ b/modules/dhcp/routing.tf
@@ -1,13 +1,13 @@
 resource "aws_nat_gateway" "eu_west_2a" {
   allocation_id = aws_eip.dns_eu_west_2a.id
-  subnet_id     = var.subnets[0]
+  subnet_id     = var.public_subnets[0]
 
   tags = var.tags
 }
 
 resource "aws_nat_gateway" "eu_west_2b" {
   allocation_id = aws_eip.dns_eu_west_2b.id
-  subnet_id     = var.subnets[1]
+  subnet_id     = var.public_subnets[1]
 
   tags = var.tags
 }

--- a/modules/dhcp/transit_gateway_attachment.tf
+++ b/modules/dhcp/transit_gateway_attachment.tf
@@ -1,7 +1,7 @@
 resource "aws_ec2_transit_gateway_vpc_attachment" "dhcp_transit_gateway_attachment" {
   count = var.enable_dhcp_transit_gateway_attachment ? 1 : 0
 
-  subnet_ids                                      = var.subnets
+  subnet_ids                                      = var.private_subnets
   transit_gateway_id                              = var.dhcp_transit_gateway_id
   vpc_id                                          = var.vpc_id
   transit_gateway_default_route_table_association = false

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -2,7 +2,11 @@ variable "prefix" {
   type = string
 }
 
-variable "subnets" {
+variable "private_subnets" {
+  type = list(string)
+}
+
+variable "public_subnets" {
   type = list(string)
 }
 

--- a/modules/dns_dhcp_common/load_balancer.tf
+++ b/modules/dns_dhcp_common/load_balancer.tf
@@ -28,7 +28,7 @@ resource "aws_lb_target_group" "target_group" {
 
   health_check {
     port = 80
-    protocol = "tcp"
+    protocol = "TCP"
   }
 
   depends_on = [aws_lb.load_balancer]


### PR DESCRIPTION
Currently the DNS servers aren't receiving traffic back from public DNS
servers. Moving these to public should allow return traffic.