### PR TITLE
VPC specific VM's require ssh public keys to be injected

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -36,6 +36,7 @@ env:
     TF_VAR_bastion_allowed_egress_ip: "/staff-device/corsham_testing/bastion_allowed_egress_ip"
     TF_VAR_pentesting_vm_ami_id: "/staff-device/bsi_testing/pentesting_vm_ami_id"
     TF_VAR_pentesting_vm_ami_ingress_cidrs: "/staff-device/bsi_testing/pentesting_vm_ami_ingress_cidrs"
+    TF_VAR_pentesting_vm_ssh_public_key: "/staff-device/bsi_testing/pentesting_vm_ssh_public_key"
     TF_VAR_corsham_vm_ip: "/staff-device/corsham_testing/corsham_vm_ip"
     TF_VAR_dhcp_egress_transit_gateway_routes: "/staff-device/$ENV/dhcp_egress_transit_gateway_routes"
     TF_VAR_byoip_pool_id: "/staff-device/dns/$ENV/public_ip_pool_id"

--- a/main.tf
+++ b/main.tf
@@ -232,6 +232,7 @@ module "bsi_test_vm_admin_vpc" {
   subnets                         = module.admin_vpc.public_subnets
   vpc_id                          = module.admin_vpc.vpc_id
   pentesting_vm_ami_id            = var.pentesting_vm_ami_id
+  pentesting_vm_ssh_public_key    = var.pentesting_vm_ssh_public_key
   pentesting_vm_ami_ingress_cidrs = var.pentesting_vm_ami_ingress_cidrs
 
   depends_on = [
@@ -250,6 +251,7 @@ module "bsi_test_vm_servers_vpc" {
   subnets                         = module.servers_vpc.public_subnets
   vpc_id                          = module.servers_vpc.vpc_id
   pentesting_vm_ami_id            = var.pentesting_vm_ami_id
+  pentesting_vm_ssh_public_key    = var.pentesting_vm_ssh_public_key
   pentesting_vm_ami_ingress_cidrs = var.pentesting_vm_ami_ingress_cidrs
 
   depends_on = [

--- a/modules/bsi_pentest_vm/main.tf
+++ b/modules/bsi_pentest_vm/main.tf
@@ -7,6 +7,7 @@ resource "aws_instance" "bsi_testing_vm" {
   ]
 
   subnet_id                   = var.subnets[0]
+  key_name                    = aws_key_pair.bsi_testing_vm_public_key_pair.key_name
   monitoring                  = true
   associate_public_ip_address = true
 
@@ -35,4 +36,12 @@ resource "aws_security_group" "sg_bsi_testing_vm" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+}
+
+resource "aws_key_pair" "bsi_testing_vm_public_key_pair" {
+  key_name_prefix = "bsi-testing-vm-pk"
+  public_key      = var.pentesting_vm_ssh_public_key
+  tags            = {
+                    Name = "DNS/DHCP BSI pen testing VM aws_key_pair"
+                  }
 }

--- a/modules/bsi_pentest_vm/main.tf
+++ b/modules/bsi_pentest_vm/main.tf
@@ -41,7 +41,7 @@ resource "aws_security_group" "sg_bsi_testing_vm" {
 resource "aws_key_pair" "bsi_testing_vm_public_key_pair" {
   key_name_prefix = "bsi-testing-vm-pk"
   public_key      = var.pentesting_vm_ssh_public_key
-  tags            = {
-                    Name = "DNS/DHCP BSI pen testing VM aws_key_pair"
-                  }
+  tags = {
+    Name = "DNS/DHCP BSI pen testing VM aws_key_pair"
+  }
 }

--- a/modules/bsi_pentest_vm/main.tf
+++ b/modules/bsi_pentest_vm/main.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "bsi_testing_vm" {
-  ami           = "ami-086f866bdf822ab3e" # Kali Linux 2020.3
+  ami           = var.pentesting_vm_ami_id
   instance_type = "t2.medium"
 
   vpc_security_group_ids = [

--- a/modules/bsi_pentest_vm/main.tf
+++ b/modules/bsi_pentest_vm/main.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "bsi_testing_vm" {
-  ami           = var.pentesting_vm_ami_id
+  ami           = "ami-086f866bdf822ab3e" # Kali Linux 2020.3
   instance_type = "t2.medium"
 
   vpc_security_group_ids = [

--- a/modules/bsi_pentest_vm/variables.tf
+++ b/modules/bsi_pentest_vm/variables.tf
@@ -10,6 +10,10 @@ variable "pentesting_vm_ami_id" {
   type = string
 }
 
+variable "pentesting_vm_ssh_public_key" {
+  type = string
+}
+
 variable "pentesting_vm_ami_ingress_cidrs" {
   type = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,10 @@ variable "pentesting_vm_ami_id" {
   type = string
 }
 
+variable "pentesting_vm_ssh_public_key" {
+  type = string
+}
+
 variable "pentesting_vm_ami_ingress_cidrs" {
   type = list(string)
 }


### PR DESCRIPTION
Two VM's are provisioned, 1 per VPC for pentesting.

These require the ssh public keys to be injected from AWS ssm.