### PR TITLE
Bump memory and CPU for tasks running in production

### DIFF
--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -1,10 +1,15 @@
+locals {
+  memory = terraform.workspace == "production" ? "2048" : "1024"
+  cpu = terraform.workspace == "production" ? "1024" : "512"
+}
+
 resource "aws_ecs_task_definition" "server_task" {
   family                   = "${var.prefix}-server-task"
   task_role_arn            = aws_iam_role.ecs_task_role.arn
   execution_role_arn       = aws_iam_role.ecs_execution_role.arn
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "512"
-  memory                   = "1024"
+  cpu                      = local.cpu
+  memory                   = local.memory
   network_mode             = "awsvpc"
 
   container_definitions = <<EOF

--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -1,6 +1,6 @@
 locals {
   memory = terraform.workspace == "production" ? "2048" : "1024"
-  cpu = terraform.workspace == "production" ? "1024" : "512"
+  cpu    = terraform.workspace == "production" ? "1024" : "512"
 }
 
 resource "aws_ecs_task_definition" "server_task" {


### PR DESCRIPTION
Scale the resources vertically as dynamic horizontal scaling is not
supported by KEA