### PR TITLE
Configure pentest vm root devices

### DIFF
--- a/modules/bsi_pentest_vm/main.tf
+++ b/modules/bsi_pentest_vm/main.tf
@@ -3,8 +3,8 @@ resource "aws_instance" "bsi_testing_vm" {
   instance_type = "t2.medium"
 
   root_block_device {
-    volume_size = 38
-    encrypted = true
+    volume_size           = 38
+    encrypted             = true
     delete_on_termination = true
   }
 

--- a/modules/bsi_pentest_vm/main.tf
+++ b/modules/bsi_pentest_vm/main.tf
@@ -2,6 +2,12 @@ resource "aws_instance" "bsi_testing_vm" {
   ami           = var.pentesting_vm_ami_id
   instance_type = "t2.medium"
 
+  root_block_device {
+    volume_size = 38
+    encrypted = true
+    delete_on_termination = true
+  }
+
   vpc_security_group_ids = [
     aws_security_group.sg_bsi_testing_vm.id
   ]


### PR DESCRIPTION
The pen-testers reported out of disk space errors and requested min 30gb free.

- Increased root device size to 38 gb
- Switched on encryption for good measure.
- ensure deleted on termination