### PR TITLE
Allow DNS ecs tasks to publish metrics

### DIFF
--- a/modules/dns/iam.tf
+++ b/modules/dns/iam.tf
@@ -35,6 +35,12 @@ resource "aws_iam_role_policy" "ecs_task_policy" {
         "s3:GetObject"
       ],
       "Resource": ["${aws_s3_bucket.config_bucket.arn}/*"]
+    },{
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:PutMetricData"
+      ],
+      "Resource": ["*"]
     }
   ]
 }


### PR DESCRIPTION
Without this IAM role our DNS tasks fail to make a PutMetricData request when publishing DNS metrics