### PR TITLE
Create basic infrastructure to support KEA HA 

### DIFF
--- a/modules/dhcp/main.tf
+++ b/modules/dhcp/main.tf
@@ -1,18 +1,23 @@
 module "dns_dhcp_common" {
-  source                              = "../dns_dhcp_common"
-  prefix                              = var.prefix
-  tags                                = var.tags
-  subnets                             = var.private_subnets
-  vpc_id                              = var.vpc_id
-  security_group_id                   = aws_security_group.dhcp_server.id
-  container_port                      = "67"
-  container_name                      = "dhcp-server"
-  task_definition_arn                 = aws_ecs_task_definition.server_task.arn
-  load_balancer_private_ip_eu_west_2a = var.load_balancer_private_ip_eu_west_2a
-  load_balancer_private_ip_eu_west_2b = var.load_balancer_private_ip_eu_west_2b
-  api_lb_target_group_arn             = aws_lb_target_group.http_api_target_group.arn
-  has_api_lb                          = true
-  desired_count                       = 2
-  max_capacity                        = 4
-  min_capacity                        = 2
+  source                  = "../dns_dhcp_common"
+  prefix                  = var.prefix
+  tags                    = var.tags
+  subnets                 = var.private_subnets
+  vpc_id                  = var.vpc_id
+  security_group_id       = aws_security_group.dhcp_server.id
+  container_port          = "67"
+  container_name          = "dhcp-server"
+  task_definition_arn     = aws_ecs_task_definition.server_task.arn
+  api_lb_target_group_arn = aws_lb_target_group.http_api_target_group.arn
+  has_api_lb              = true
+  desired_count           = 1
+  max_capacity            = 1
+  min_capacity            = 1
+
+  load_balancer_config = {
+    eu_west_2a = {
+      subnet_id            = var.private_subnets[0]
+      private_ipv4_address = var.load_balancer_private_ip_eu_west_2a
+    }
+  }
 }

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -13,6 +13,7 @@ output "kea_config_bucket_name" {
 output "ecs" {
   value = {
     cluster_name         = module.dns_dhcp_common.ecs.cluster_name
+    cluster_id           = module.dns_dhcp_common.ecs.cluster_id
     service_name         = module.dns_dhcp_common.ecs.service_name
     service_arn          = module.dns_dhcp_common.ecs.service_arn
     task_definition_name = aws_ecs_task_definition.server_task.family
@@ -22,7 +23,19 @@ output "ecs" {
 output "rds" {
   value = {
     endpoint = aws_db_instance.dhcp_server_db.endpoint
+    name     = aws_db_instance.dhcp_server_db.name
   }
+}
+
+output "iam" {
+  value = {
+    task_execution_role_arn = aws_iam_role.ecs_execution_role.arn
+    task_role_arn           = aws_iam_role.ecs_task_role.arn
+  }
+}
+
+output "cloudwatch" {
+  value = module.dns_dhcp_common.cloudwatch
 }
 
 output "ecr" {
@@ -51,4 +64,10 @@ output "db_host" {
 
 output "db_port" {
   value = aws_db_instance.dhcp_server_db.port
+}
+
+output "ec2" {
+  value = {
+    dhcp_server_security_group_id = aws_security_group.dhcp_server.id
+  }
 }

--- a/modules/dhcp/security_groups.tf
+++ b/modules/dhcp/security_groups.tf
@@ -75,10 +75,10 @@ resource "aws_security_group" "dhcp_db_in" {
 }
 
 resource "aws_security_group_rule" "dhcp_db_in" {
-  type                     = "ingress"
-  from_port                = 3306
-  to_port                  = 3306
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.dhcp_db_in.id
-  source_security_group_id = aws_security_group.dhcp_server.id
+  type              = "ingress"
+  from_port         = 3306
+  to_port           = 3306
+  protocol          = "tcp"
+  security_group_id = aws_security_group.dhcp_db_in.id
+  cidr_blocks       = [var.vpc_cidr]
 }

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -6,10 +6,6 @@ variable "private_subnets" {
   type = list(string)
 }
 
-variable "env" {
-  type = string
-}
-
 variable "tags" {
   type = map(string)
 }
@@ -47,10 +43,6 @@ variable "vpn_hosted_zone_domain" {
 }
 
 variable "short_prefix" {
-  type = string
-}
-
-variable "region" {
   type = string
 }
 

--- a/modules/dhcp_standby/ecs.tf
+++ b/modules/dhcp_standby/ecs.tf
@@ -1,0 +1,24 @@
+resource "aws_ecs_service" "service" {
+  name            = "${var.prefix}-service"
+  cluster         = var.dhcp_server_cluster_id
+  task_definition = aws_ecs_task_definition.server_task.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.target_group.arn
+    container_name   = var.container_name
+    container_port   = var.container_port
+  }
+
+  network_configuration {
+    subnets = var.private_subnets
+
+    security_groups = [
+      var.dhcp_server_security_group_id
+    ]
+
+    assign_public_ip = true
+  }
+}
+

--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -1,0 +1,97 @@
+locals {
+  memory = terraform.workspace == "production" ? "2048" : "1024"
+  cpu    = terraform.workspace == "production" ? "1024" : "512"
+}
+
+resource "aws_ecs_task_definition" "server_task" {
+  family                   = "${var.prefix}-server-task"
+  task_role_arn            = var.ecs_task_role_arn
+  execution_role_arn       = var.ecs_task_execution_role_arn
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = local.cpu
+  memory                   = local.memory
+  network_mode             = "awsvpc"
+
+  container_definitions = <<EOF
+[
+  {
+    "portMappings": [
+      {
+        "hostPort": 67,
+        "containerPort": 67,
+        "protocol": "udp"
+      },
+      {
+        "hostPort": 8000,
+        "containerPort": 8000,
+        "protocol": "tcp"
+      }
+    ],
+    "essential": true,
+    "name": "dhcp-server",
+    "environment": [
+      {
+        "name": "DB_NAME",
+        "value": "${var.dhcp_server_db_name}"
+      },
+      {
+        "name": "DB_USER",
+        "value": "${var.dhcp_db_username}"
+      },
+      {
+        "name": "DB_PASS",
+        "value": "${var.dhcp_db_password}"
+      },
+      {
+        "name": "DB_HOST",
+        "value": "${var.dhcp_db_host}"
+      },
+      {
+        "name": "DB_PORT",
+        "value": "3306"
+      },
+      {
+        "name": "INTERFACE",
+        "value": "eth0"
+      },
+      {
+        "name": "KEA_CONFIG_BUCKET_NAME",
+        "value": "${var.kea_config_bucket_name}"
+      },
+      {
+        "name": "ECS_ENABLE_CONTAINER_METADATA",
+        "value": "true"
+      }
+    ],
+    "image": "${var.dhcp_repository_url}",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${var.server_log_group_name}",
+        "awslogs-region": "eu-west-2",
+        "awslogs-stream-prefix": "eu-west-2-docker-logs"
+      }
+    },
+    "expanded": true
+  }, {
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${var.nginx_log_group_name}",
+        "awslogs-region": "eu-west-2",
+        "awslogs-stream-prefix": "eu-west-2-docker-logs"
+      }
+    },
+    "portMappings": [
+      {
+        "hostPort": 80,
+        "protocol": "tcp",
+        "containerPort": 80
+      }
+    ],
+    "image": "${var.nginx_repository_url}",
+    "name": "NGINX"
+  }
+]
+EOF
+}

--- a/modules/dhcp_standby/load_balancer.tf
+++ b/modules/dhcp_standby/load_balancer.tf
@@ -3,16 +3,9 @@ resource "aws_lb" "load_balancer" {
   load_balancer_type = "network"
   internal           = true
 
-  dynamic "subnet_mapping" {
-    for_each = [for c in var.load_balancer_config : {
-      subnet_id            = c.subnet_id
-      private_ipv4_address = c.private_ipv4_address
-    }]
-
-    content {
-      subnet_id            = subnet_mapping.value.subnet_id
-      private_ipv4_address = subnet_mapping.value.private_ipv4_address
-    }
+  subnet_mapping {
+    subnet_id            = var.private_subnets[1]
+    private_ipv4_address = var.load_balancer_private_ip_eu_west_2b
   }
 
   enable_deletion_protection = false
@@ -24,7 +17,7 @@ resource "aws_lb_target_group" "target_group" {
   name                 = var.prefix
   protocol             = "TCP_UDP"
   vpc_id               = var.vpc_id
-  port                 = var.container_port
+  port                 = "67"
   target_type          = "ip"
   deregistration_delay = 300
 
@@ -38,7 +31,7 @@ resource "aws_lb_target_group" "target_group" {
 
 resource "aws_lb_listener" "udp" {
   load_balancer_arn = aws_lb.load_balancer.arn
-  port              = var.container_port
+  port              = "67"
   protocol          = "UDP"
 
   default_action {

--- a/modules/dhcp_standby/variables.tf
+++ b/modules/dhcp_standby/variables.tf
@@ -1,0 +1,89 @@
+variable "prefix" {
+  type = string
+}
+
+variable "private_subnets" {
+  type = list(string)
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "dhcp_db_username" {
+  type = string
+}
+
+variable "dhcp_db_password" {
+  type = string
+}
+
+variable "load_balancer_private_ip_eu_west_2a" {
+  type = string
+}
+
+variable "load_balancer_private_ip_eu_west_2b" {
+  type = string
+}
+
+variable "nginx_repository_url" {
+  type = string
+}
+
+variable "nginx_log_group_name" {
+  type = string
+}
+
+variable "server_log_group_name" {
+  type = string
+}
+
+variable "dhcp_repository_url" {
+  type = string
+}
+
+variable "dhcp_db_host" {
+  type = string
+}
+
+variable "dhcp_server_db_name" {
+  type = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  type = string
+}
+
+variable "ecs_task_role_arn" {
+  type = string
+}
+
+variable "dhcp_server_cluster_id" {
+  type = string
+}
+
+variable "container_port" {
+  type    = string
+  default = "67"
+}
+
+variable "container_name" {
+  type    = string
+  default = "dhcp-server"
+}
+
+variable "kea_config_bucket_name" {
+  type = string
+}
+
+variable "dhcp_server_security_group_id" {
+  type = string
+}

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,17 +1,26 @@
 module "dns_dhcp_common" {
-  source                              = "../dns_dhcp_common"
-  prefix                              = var.prefix
-  vpc_id                              = var.vpc_id
-  tags                                = var.tags
-  subnets                             = var.subnets
-  container_name                      = "dns-server"
-  container_port                      = "53"
-  security_group_id                   = aws_security_group.dns_server.id
-  task_definition_arn                 = aws_ecs_task_definition.server_task.arn
-  load_balancer_private_ip_eu_west_2a = var.load_balancer_private_ip_eu_west_2a
-  load_balancer_private_ip_eu_west_2b = var.load_balancer_private_ip_eu_west_2b
-  desired_count                       = 2
-  max_capacity                        = 6
-  min_capacity                        = 2
+  source              = "../dns_dhcp_common"
+  prefix              = var.prefix
+  vpc_id              = var.vpc_id
+  tags                = var.tags
+  subnets             = var.subnets
+  container_name      = "dns-server"
+  container_port      = "53"
+  security_group_id   = aws_security_group.dns_server.id
+  task_definition_arn = aws_ecs_task_definition.server_task.arn
+  desired_count       = 2
+  max_capacity        = 6
+  min_capacity        = 2
+
+  load_balancer_config = {
+    eu_west_2a = {
+      subnet_id            = var.subnets[0]
+      private_ipv4_address = var.load_balancer_private_ip_eu_west_2a
+    },
+    eu_west_2b = {
+      subnet_id            = var.subnets[1]
+      private_ipv4_address = var.load_balancer_private_ip_eu_west_2b
+    }
+  }
 
 }

--- a/modules/dns_dhcp_common/outputs.tf
+++ b/modules/dns_dhcp_common/outputs.tf
@@ -1,7 +1,7 @@
 output "ecr" {
   value = {
-    repository_url = aws_ecr_repository.docker_repository.repository_url
-    registry_id    = aws_ecr_repository.docker_repository.registry_id
+    repository_url       = aws_ecr_repository.docker_repository.repository_url
+    registry_id          = aws_ecr_repository.docker_repository.registry_id
     nginx_repository_url = aws_ecr_repository.docker_repository_nginx.repository_url
   }
 }
@@ -9,6 +9,7 @@ output "ecr" {
 output "ecs" {
   value = {
     cluster_name = aws_ecs_cluster.server_cluster.name
+    cluster_id   = aws_ecs_cluster.server_cluster.id
     service_name = aws_ecs_service.service.name
     service_arn  = aws_ecs_service.service.id
   }
@@ -23,7 +24,7 @@ output "nlb" {
 
 output "cloudwatch" {
   value = {
-    server_log_group_name = aws_cloudwatch_log_group.server_log_group.name
+    server_log_group_name       = aws_cloudwatch_log_group.server_log_group.name
     server_nginx_log_group_name = aws_cloudwatch_log_group.server_nginx_log_group.name
   }
 }

--- a/modules/dns_dhcp_common/variables.tf
+++ b/modules/dns_dhcp_common/variables.tf
@@ -26,14 +26,6 @@ variable "task_definition_arn" {
   type = string
 }
 
-variable "load_balancer_private_ip_eu_west_2a" {
-  type = string
-}
-
-variable "load_balancer_private_ip_eu_west_2b" {
-  type = string
-}
-
 variable "vpc_id" {
   type = string
 }
@@ -58,4 +50,8 @@ variable "max_capacity" {
 
 variable "min_capacity" {
   type = number
+}
+
+variable "load_balancer_config" {
+  type = map
 }


### PR DESCRIPTION
This creates the standby service infrastructure in the DHCP cluster.
The current (primary) and new secondary services will sync leases
between each other.

Same docker image, s3 configuration, IAM and Security group
configurations will be used by both primary and standby.