### PR TITLE
Fix health checks for API dhcp service

### DIFF
--- a/modules/dhcp/http_api_load_balancer.tf
+++ b/modules/dhcp/http_api_load_balancer.tf
@@ -19,6 +19,7 @@ resource "aws_lb_target_group" "http_api_target_group" {
 
   health_check {
     port = 80
+    protocol = "TCP"
   }
 
   depends_on = [aws_lb.http_api_load_balancer]

--- a/modules/dhcp/main.tf
+++ b/modules/dhcp/main.tf
@@ -13,6 +13,7 @@ module "dns_dhcp_common" {
   desired_count           = 1
   max_capacity            = 1
   min_capacity            = 1
+  has_api_service = true
 
   load_balancer_config = {
     eu_west_2a = {

--- a/modules/dhcp/security_groups.tf
+++ b/modules/dhcp/security_groups.tf
@@ -13,10 +13,7 @@ resource "aws_security_group_rule" "dhcp_container_healthcheck" {
   to_port           = 80
   protocol          = "tcp"
   security_group_id = aws_security_group.dhcp_server.id
-  cidr_blocks = [
-    "${var.load_balancer_private_ip_eu_west_2a}/32",
-    "${var.load_balancer_private_ip_eu_west_2b}/32"
-  ]
+  cidr_blocks       = [var.vpc_cidr]
 }
 
 resource "aws_security_group_rule" "dhcp_container_kea_api_in" {

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -11,6 +11,7 @@ module "dns_dhcp_common" {
   desired_count       = 2
   max_capacity        = 6
   min_capacity        = 2
+  has_api_service     = false
 
   load_balancer_config = {
     eu_west_2a = {

--- a/modules/dns_dhcp_common/ecs.tf
+++ b/modules/dns_dhcp_common/ecs.tf
@@ -20,16 +20,6 @@ resource "aws_ecs_service" "service" {
     container_port   = var.container_port
   }
 
-  dynamic "load_balancer" {
-    for_each = var.has_api_lb ? [1] : []
-
-    content {
-      target_group_arn = var.api_lb_target_group_arn
-      container_name   = var.container_name
-      container_port   = "8000"
-    }
-  }
-
   network_configuration {
     subnets = var.subnets
 
@@ -41,3 +31,28 @@ resource "aws_ecs_service" "service" {
   }
 }
 
+resource "aws_ecs_service" "api_service" {
+  count = var.has_api_service ? 1 : 0
+
+  name            = "${var.prefix}-api-service"
+  cluster         = aws_ecs_cluster.server_cluster.id
+  task_definition = var.task_definition_arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  load_balancer {
+    target_group_arn = var.api_lb_target_group_arn
+    container_name   = var.container_name
+    container_port   = "8000"
+  }
+
+  network_configuration {
+    subnets = [var.subnets[0]]
+
+    security_groups = [
+      var.security_group_id
+    ]
+
+    assign_public_ip = true
+  }
+}

--- a/modules/dns_dhcp_common/variables.tf
+++ b/modules/dns_dhcp_common/variables.tf
@@ -55,3 +55,7 @@ variable "min_capacity" {
 variable "load_balancer_config" {
   type = map
 }
+
+variable "has_api_service" {
+  type = bool
+}


### PR DESCRIPTION
Allow ingress traffic on port 80 from vpc.
This used to just allow the 2 main load balancers to perform health
checks. Allow the API load balancer to perform health checks as well.