### PR TITLE
Boot the API as standby not primary

### DIFF
--- a/modules/dhcp/ecs.tf
+++ b/modules/dhcp/ecs.tf
@@ -40,7 +40,7 @@ resource "aws_ecs_service" "service" {
 resource "aws_ecs_service" "api_service" {
   name            = "${var.prefix}-api-service"
   cluster         = aws_ecs_cluster.server_cluster.id
-  task_definition = aws_ecs_task_definition.server_task.arn
+  task_definition = aws_ecs_task_definition.api_server_task.arn
   desired_count   = "1"
   launch_type     = "FARGATE"
 

--- a/modules/dhcp/ecs_task_definition_api.tf
+++ b/modules/dhcp/ecs_task_definition_api.tf
@@ -1,0 +1,99 @@
+resource "aws_ecs_task_definition" "api_server_task" {
+  family                   = "${var.prefix}-api-server-task"
+  task_role_arn            = module.dns_dhcp_common.iam.ecs_task_role_arn
+  execution_role_arn       = module.dns_dhcp_common.iam.ecs_execution_role_arn
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  network_mode             = "awsvpc"
+
+  container_definitions = <<EOF
+[
+  {
+    "portMappings": [
+      {
+        "hostPort": 8000,
+        "containerPort": 8000,
+        "protocol": "tcp"
+      }
+    ],
+    "essential": true,
+    "name": "dhcp-server",
+    "environment": [
+      {
+        "name": "DB_NAME",
+        "value": "${aws_db_instance.dhcp_server_db.name}"
+      },
+      {
+        "name": "DB_USER",
+        "value": "${var.dhcp_db_username}"
+      },
+      {
+        "name": "DB_PASS",
+        "value": "${var.dhcp_db_password}"
+      },
+      {
+        "name": "DB_HOST",
+        "value": "${aws_route53_record.dhcp_db.fqdn}"
+      },
+      {
+        "name": "DB_PORT",
+        "value": "${aws_db_instance.dhcp_server_db.port}"
+      },
+      {
+        "name": "INTERFACE",
+        "value": "eth0"
+      },
+      {
+        "name": "KEA_CONFIG_BUCKET_NAME",
+        "value": "${var.prefix}-config-bucket"
+      },
+      {
+        "name": "ECS_ENABLE_CONTAINER_METADATA",
+        "value": "true"
+      },
+      {
+        "name": "SERVER_NAME",
+        "value": "standby"
+      },
+      {
+        "name": "PRIMARY_IP",
+        "value": "${var.load_balancer_private_ip_eu_west_2a}"
+      },
+      {
+        "name": "STANDBY_IP",
+        "value": "${var.load_balancer_private_ip_eu_west_2b}"
+      }
+    ],
+    "image": "${module.dns_dhcp_common.ecr.repository_url}",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${module.dns_dhcp_common.cloudwatch.server_log_group_name}",
+        "awslogs-region": "eu-west-2",
+        "awslogs-stream-prefix": "eu-west-2-docker-logs"
+      }
+    },
+    "expanded": true
+  }, {
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${module.dns_dhcp_common.cloudwatch.server_nginx_log_group_name}",
+        "awslogs-region": "eu-west-2",
+        "awslogs-stream-prefix": "eu-west-2-docker-logs"
+      }
+    },
+    "portMappings": [
+      {
+        "hostPort": 80,
+        "protocol": "tcp",
+        "containerPort": 80
+      }
+    ],
+    "image": "${module.dns_dhcp_common.ecr.nginx_repository_url}",
+    "name": "NGINX"
+  }
+]
+EOF
+}

--- a/modules/dhcp/security_groups.tf
+++ b/modules/dhcp/security_groups.tf
@@ -23,7 +23,7 @@ resource "aws_security_group_rule" "dhcp_container_kea_api_in" {
   to_port           = 8000
   protocol          = "tcp"
   security_group_id = aws_security_group.dhcp_server.id
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks       = ["0.0.0.0/0"]
 }
 
 resource "aws_security_group_rule" "dhcp_container_kea_api_out" {


### PR DESCRIPTION
The API (used to validate configurations and list leases to the admin)
is currently booting as a primary server in the peer relationship.
This means that the API is sending heartbeats to the standby server and
standby won't ever consider primary as down.

Removing the HA config from the API would require a copy of all the
underlying ECS infrastructure and a separate configuration file.

By booting the API as standby, it won't interfere with the 2 peers when
detecting if they are up or not.