### PR TITLE
Dedicated CloudWatch log groups for Standby and API

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,8 +98,6 @@ module "dhcp_standby" {
   load_balancer_private_ip_eu_west_2b = var.dhcp_load_balancer_private_ip_eu_west_2b
   vpc_cidr                            = local.dns_dhcp_vpc_cidr
   nginx_repository_url                = module.dhcp.ecr.nginx_repository_url
-  nginx_log_group_name                = module.dhcp.cloudwatch.server_nginx_log_group_name
-  server_log_group_name               = module.dhcp.cloudwatch.server_log_group_name
   dhcp_repository_url                 = module.dhcp.ecr.repository_url
   dhcp_db_host                        = module.dhcp.db_host
   dhcp_server_db_name                 = module.dhcp.rds.name

--- a/modules/dhcp/api_logging.tf
+++ b/modules/dhcp/api_logging.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_log_group" "server_log_group" {
+  name = "${var.prefix}-api-server-log-group"
+
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "server_nginx_log_group" {
+  name = "${var.prefix}-api-server-nginx-log-group"
+
+  retention_in_days = 7
+}

--- a/modules/dhcp/ecs_task_definition_api.tf
+++ b/modules/dhcp/ecs_task_definition_api.tf
@@ -69,7 +69,7 @@ resource "aws_ecs_task_definition" "api_server_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${module.dns_dhcp_common.cloudwatch.server_log_group_name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
         "awslogs-region": "eu-west-2",
         "awslogs-stream-prefix": "eu-west-2-docker-logs"
       }
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "api_server_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${module.dns_dhcp_common.cloudwatch.server_nginx_log_group_name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.server_nginx_log_group.name}",
         "awslogs-region": "eu-west-2",
         "awslogs-stream-prefix": "eu-west-2-docker-logs"
       }

--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "server_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${var.server_log_group_name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.server_log_group.name}",
         "awslogs-region": "eu-west-2",
         "awslogs-stream-prefix": "eu-west-2-docker-logs"
       }
@@ -89,7 +89,7 @@ resource "aws_ecs_task_definition" "server_task" {
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "${var.nginx_log_group_name}",
+        "awslogs-group": "${aws_cloudwatch_log_group.server_nginx_log_group.name}",
         "awslogs-region": "eu-west-2",
         "awslogs-stream-prefix": "eu-west-2-docker-logs"
       }

--- a/modules/dhcp_standby/logging.tf
+++ b/modules/dhcp_standby/logging.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_log_group" "server_log_group" {
+  name = "${var.prefix}-standby-server-log-group"
+
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "server_nginx_log_group" {
+  name = "${var.prefix}-standby-server-nginx-log-group"
+
+  retention_in_days = 7
+}

--- a/modules/dhcp_standby/variables.tf
+++ b/modules/dhcp_standby/variables.tf
@@ -42,14 +42,6 @@ variable "nginx_repository_url" {
   type = string
 }
 
-variable "nginx_log_group_name" {
-  type = string
-}
-
-variable "server_log_group_name" {
-  type = string
-}
-
 variable "dhcp_repository_url" {
   type = string
 }


### PR DESCRIPTION
These are currently all going to the primary server log group
For ease of debugging, dedicate log groups to each of the peers.