### PR TITLE
Output the service names of the API and Standby

### DIFF
--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -20,6 +20,12 @@ output "ecs" {
   }
 }
 
+output "ecs_dhcp_api" {
+  value = {
+    service_name = aws_ecs_service.api_service.name
+  }
+}
+
 output "rds" {
   value = {
     endpoint = aws_db_instance.dhcp_server_db.endpoint

--- a/modules/dhcp_standby/outputs.tf
+++ b/modules/dhcp_standby/outputs.tf
@@ -1,0 +1,5 @@
+output "ecs" {
+  value = {
+    service_name = aws_ecs_service.service.name
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,6 +5,14 @@ output "terraform_outputs" {
       ecr = module.dhcp.ecr
     }
 
+    dhcp_standby = {
+      ecs = module.dhcp_standby.ecs
+    }
+
+    dhcp_api = {
+      ecs = module.dhcp.ecs_dhcp_api
+    }
+
     dns = {
       ecs = module.dns.ecs
       ecr = module.dns.ecr


### PR DESCRIPTION
These outputs will be published to Parameter store and picked up by the DHCP
server deployment script.

In addition to primary, standby and the API will be deployed as well.  These values are needed to find out what the service names are to deploy.