### PR TITLE
Allow ECS to list objects in the S3 KEA config bucket

### DIFF
--- a/modules/dns_dhcp_common/iam.tf
+++ b/modules/dns_dhcp_common/iam.tf
@@ -32,7 +32,8 @@ resource "aws_iam_role_policy" "ecs_task_policy" {
     },{
       "Effect": "Allow",
       "Action": [
-        "s3:GetObject"
+        "s3:GetObject",
+        "s3:ListBucket"
       ],
       "Resource": ["${aws_s3_bucket.config_bucket.arn}/*"]
     },{


### PR DESCRIPTION
The configurations are now reloaded without rebuilding the containers.
The KEA server uses s3 sync instead of s3 cp, which requires the list
bucket permissions.