### PR TITLE
Update VPC name and primary dhcp service name

### DIFF
--- a/modules/dhcp/ecs.tf
+++ b/modules/dhcp/ecs.tf
@@ -8,7 +8,7 @@ resource "aws_ecs_cluster" "server_cluster" {
 }
 
 resource "aws_ecs_service" "service" {
-  name            = "${var.prefix}-service"
+  name            = "${var.prefix}-primary-service"
   cluster         = aws_ecs_cluster.server_cluster.id
   task_definition = aws_ecs_task_definition.server_task.arn
   desired_count   = 1

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -13,7 +13,7 @@ resource "aws_security_group" "endpoints" {
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.50.0"
-  name    = var.prefix
+  name    = "${var.prefix}-dns"
 
   cidr                 = var.cidr_block
   enable_dns_hostnames = true


### PR DESCRIPTION
The vpc houses both DNS and DHCP, the name needs to reflect this.
The primary service name doesn't have the word primary in it, so add
this.