### PR TITLE
Clear AWS vpc default sg rules

### DIFF
--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -52,4 +52,8 @@ module "vpc" {
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2),
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 3)
   ]
+
+  manage_default_security_group  = true
+  default_security_group_ingress = [{}]
+  default_security_group_egress  = [{}]
 }

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -54,6 +54,6 @@ module "vpc" {
   ]
 
   manage_default_security_group  = true
-  default_security_group_ingress = [{}]
-  default_security_group_egress  = [{}]
+  default_security_group_ingress = []
+  default_security_group_egress  = []
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -17,4 +17,8 @@ module "vpc" {
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 1),
     cidrsubnet(var.cidr_block, var.cidr_block_new_bits, 2)
   ]
+
+  manage_default_security_group  = true
+  default_security_group_ingress = [{}]
+  default_security_group_egress  = [{}]
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -19,6 +19,6 @@ module "vpc" {
   ]
 
   manage_default_security_group  = true
-  default_security_group_ingress = [{}]
-  default_security_group_egress  = [{}]
+  default_security_group_ingress = []
+  default_security_group_egress  = []
 }


### PR DESCRIPTION
**What**

"Imports" the default VPC security groups into terraform management and deletes the open sg rules.

**Notes**

- The default security group can not be deleted and has open ingress and egress rules by default.
-  See:  [Terraform Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group)