### PR TITLE
Only publish metrics from the Primary instance

### DIFF
--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -73,6 +73,10 @@ resource "aws_ecs_task_definition" "server_task" {
       {
         "name": "STANDBY_IP",
         "value": "${var.load_balancer_private_ip_eu_west_2b}"
+      },
+      {
+        "name": "PUBLISH_METRICS",
+        "value": "true"
       }
     ],
     "image": "${module.dns_dhcp_common.ecr.repository_url}",

--- a/modules/dhcp/ecs_task_definition_api.tf
+++ b/modules/dhcp/ecs_task_definition_api.tf
@@ -63,6 +63,10 @@ resource "aws_ecs_task_definition" "api_server_task" {
       {
         "name": "STANDBY_IP",
         "value": "${var.load_balancer_private_ip_eu_west_2b}"
+      },
+      {
+        "name": "PUBLISH_METRICS",
+        "value": "false"
       }
     ],
     "image": "${module.dns_dhcp_common.ecr.repository_url}",

--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -73,6 +73,10 @@ resource "aws_ecs_task_definition" "server_task" {
       {
         "name": "STANDBY_IP",
         "value": "${var.load_balancer_private_ip_eu_west_2b}"
+      },
+      {
+        "name": "PUBLISH_METRICS",
+        "value": "false"
       }
     ],
     "image": "${var.dhcp_repository_url}",


### PR DESCRIPTION
Currently the API, standby and primary are publishing the same in memory
metrics which could lead to skewed results.