### PR TITLE
Double memory and CPU of ECS for DHCP in production

### DIFF
--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -1,6 +1,6 @@
 locals {
-  memory = terraform.workspace == "production" ? "2048" : "1024"
-  cpu    = terraform.workspace == "production" ? "1024" : "512"
+  memory = terraform.workspace == "production" ? "4096" : "1024"
+  cpu    = terraform.workspace == "production" ? "2048" : "512"
 }
 
 resource "aws_ecs_task_definition" "server_task" {


### PR DESCRIPTION
We are currently doing performance testing and this is to see how it
affects the tests if the resources are doubled.

After the test, this will be reverted to the original values.