### PR TITLE
Create log metric filters for KEA

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ env:
     TF_VAR_admin_db_backup_retention_period: 30
     TF_VAR_enable_dhcp_transit_gateway_attachment: true
     TF_VAR_enable_ssh_key_generation: false
+    TF_VAR_enable_dhcp_cloudwatch_log_metrics: true
   parameter-store:
     TF_VAR_assume_role: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
     TF_VAR_pdns_ips: "/staff-device/dns/pdns/ips"

--- a/main.tf
+++ b/main.tf
@@ -132,6 +132,7 @@ module "dhcp" {
   is_publicly_accessible               = local.publicly_accessible
   vpc_cidr                             = local.dns_dhcp_vpc_cidr
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
+  enable_dhcp_cloudwatch_log_metrics   = var.enable_dhcp_cloudwatch_log_metrics
 
   providers = {
     aws = aws.env

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,10 @@ module "dhcp_standby" {
   ]
 }
 
+locals {
+  metrics_namespace = "Kea-DHCP-Service"
+}
+
 module "dhcp" {
   source                               = "./modules/dhcp"
   prefix                               = module.dhcp_label.id
@@ -132,7 +136,20 @@ module "dhcp" {
   is_publicly_accessible               = local.publicly_accessible
   vpc_cidr                             = local.dns_dhcp_vpc_cidr
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
-  enable_dhcp_cloudwatch_log_metrics   = var.enable_dhcp_cloudwatch_log_metrics
+  metrics_namespace                    = local.metrics_namespace
+  dhcp_log_search_metric_filters       = var.enable_dhcp_cloudwatch_log_metrics == true ? [
+    "FATAL",
+    "ERROR",
+    "WARN",
+    "HTTP_PREMATURE_CONNECTION_TIMEOUT_OCCURRED",
+    "ALLOC_ENGINE_V4_ALLOC_ERROR",
+    "ALLOC_ENGINE_V4_ALLOC_FAIL",
+    "ALLOC_ENGINE_V4_ALLOC_FAIL_CLASSES",
+    "DHCP4_PACKET_NAK_0001",
+    "HA_SYNC_FAILED",
+    "HA_HEARTBEAT_COMMUNICATIONS_FAILED",
+    "HA_DHCP_DISABLE_COMMUNICATIONS_FAILED"
+  ] : []
 
   providers = {
     aws = aws.env

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ module "dhcp" {
   vpc_cidr                             = local.dns_dhcp_vpc_cidr
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
   metrics_namespace                    = local.metrics_namespace
-  dhcp_log_search_metric_filters       = var.enable_dhcp_cloudwatch_log_metrics == true ? [
+  dhcp_log_search_metric_filters = var.enable_dhcp_cloudwatch_log_metrics == true ? [
     "FATAL",
     "ERROR",
     "WARN",

--- a/modules/dhcp/log_metrics.tf
+++ b/modules/dhcp/log_metrics.tf
@@ -6,9 +6,9 @@ resource "aws_cloudwatch_log_metric_filter" "kea_dhcp_filter" {
   log_group_name = module.dns_dhcp_common.cloudwatch.server_log_group_name
 
   metric_transformation {
-    name      = each.value
-    namespace = var.metrics_namespace
-    value     = "1"
+    name          = each.value
+    namespace     = var.metrics_namespace
+    value         = "1"
     default_value = "0"
   }
 }

--- a/modules/dhcp/log_metrics.tf
+++ b/modules/dhcp/log_metrics.tf
@@ -2,6 +2,7 @@ locals {
   metrics_namespace = "Kea-DHCP-Service"
 
   log_search_terms = var.enable_dhcp_cloudwatch_log_metrics == true ? toset([
+    "FATAL",
     "ERROR",
     "WARN",
     "HTTP_PREMATURE_CONNECTION_TIMEOUT_OCCURRED",

--- a/modules/dhcp/log_metrics.tf
+++ b/modules/dhcp/log_metrics.tf
@@ -1,0 +1,31 @@
+locals {
+  metrics_namespace = "Kea-DHCP-Service"
+
+  log_search_terms = var.enable_dhcp_cloudwatch_log_metrics == true ? toset([
+    "ERROR",
+    "WARN",
+    "HTTP_PREMATURE_CONNECTION_TIMEOUT_OCCURRED",
+    "ALLOC_ENGINE_V4_ALLOC_ERROR",
+    "ALLOC_ENGINE_V4_ALLOC_FAIL",
+    "ALLOC_ENGINE_V4_ALLOC_FAIL_CLASSES",
+    "DHCP4_PACKET_NAK_0001",
+    "HA_SYNC_FAILED",
+    "HA_HEARTBEAT_COMMUNICATIONS_FAILED",
+    "HA_DHCP_DISABLE_COMMUNICATIONS_FAILED"
+  ]) : []
+}
+
+resource "aws_cloudwatch_log_metric_filter" "kea_dhcp_filter" {
+  for_each = local.log_search_terms
+
+  name           = each.value
+  pattern        = each.value
+  log_group_name = module.dns_dhcp_common.cloudwatch.server_log_group_name
+
+  metric_transformation {
+    name      = each.value
+    namespace = local.metrics_namespace
+    value     = "1"
+    default_value = "0"
+  }
+}

--- a/modules/dhcp/log_metrics.tf
+++ b/modules/dhcp/log_metrics.tf
@@ -23,9 +23,9 @@ resource "aws_cloudwatch_log_metric_filter" "kea_dhcp_filter" {
   log_group_name = module.dns_dhcp_common.cloudwatch.server_log_group_name
 
   metric_transformation {
-    name      = each.value
-    namespace = local.metrics_namespace
-    value     = "1"
+    name          = each.value
+    namespace     = local.metrics_namespace
+    value         = "1"
     default_value = "0"
   }
 }

--- a/modules/dhcp/log_metrics.tf
+++ b/modules/dhcp/log_metrics.tf
@@ -1,32 +1,14 @@
-locals {
-  metrics_namespace = "Kea-DHCP-Service"
-
-  log_search_terms = var.enable_dhcp_cloudwatch_log_metrics == true ? toset([
-    "FATAL",
-    "ERROR",
-    "WARN",
-    "HTTP_PREMATURE_CONNECTION_TIMEOUT_OCCURRED",
-    "ALLOC_ENGINE_V4_ALLOC_ERROR",
-    "ALLOC_ENGINE_V4_ALLOC_FAIL",
-    "ALLOC_ENGINE_V4_ALLOC_FAIL_CLASSES",
-    "DHCP4_PACKET_NAK_0001",
-    "HA_SYNC_FAILED",
-    "HA_HEARTBEAT_COMMUNICATIONS_FAILED",
-    "HA_DHCP_DISABLE_COMMUNICATIONS_FAILED"
-  ]) : []
-}
-
 resource "aws_cloudwatch_log_metric_filter" "kea_dhcp_filter" {
-  for_each = local.log_search_terms
+  for_each = toset(var.dhcp_log_search_metric_filters)
 
   name           = each.value
   pattern        = each.value
   log_group_name = module.dns_dhcp_common.cloudwatch.server_log_group_name
 
   metric_transformation {
-    name          = each.value
-    namespace     = local.metrics_namespace
-    value         = "1"
+    name      = each.value
+    namespace = var.metrics_namespace
+    value     = "1"
     default_value = "0"
   }
 }

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -84,3 +84,7 @@ output "ec2" {
     dhcp_server_security_group_id = aws_security_group.dhcp_server.id
   }
 }
+
+output "kea_metrics_namespace" {
+  value = var.metrics_namespace
+}

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -54,6 +54,10 @@ variable "admin_local_development_domain_affix" {
   type = string
 }
 
-variable "enable_dhcp_cloudwatch_log_metrics" {
-  type = bool
+variable "metrics_namespace" {
+  type = string
+}
+
+variable "dhcp_log_search_metric_filters" {
+  type = set(string)
 }

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -53,3 +53,7 @@ variable "is_publicly_accessible" {
 variable "admin_local_development_domain_affix" {
   type = string
 }
+
+variable "enable_dhcp_cloudwatch_log_metrics" {
+  type = bool
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,6 +22,8 @@ output "terraform_outputs" {
       ecs = module.admin.ecs
     }
 
+    metrics_namespace = local.metrics_namespace
+
     authentication = {
       cognito = {
         identifier_urn = module.authentication.cognito_identifier_urn

--- a/variables.tf
+++ b/variables.tf
@@ -129,6 +129,6 @@ variable "byoip_pool_id" {
 }
 
 variable "enable_dhcp_cloudwatch_log_metrics" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -127,3 +127,8 @@ variable "corsham_vm_ip" {
 variable "byoip_pool_id" {
   type = string
 }
+
+variable "enable_dhcp_cloudwatch_log_metrics" {
+  type = bool
+  default = false
+}


### PR DESCRIPTION
Log entries matching certain keywords will be converted to metrics.
These will be added to the existing CloudWatch metrics namespace and
displayed in Grafana.

This will make interesting events in KEA visible in Grafana.