### PR TITLE
Set sql_mode to STRICT_ALL_TABLES

### DIFF
--- a/modules/admin/db.tf
+++ b/modules/admin/db.tf
@@ -28,6 +28,8 @@ resource "aws_db_instance" "admin_db" {
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
 
+  parameter_group_name = aws_db_parameter_group.admin_db_parameter_group.name
+
   tags = var.tags
 }
 
@@ -36,4 +38,15 @@ resource "aws_db_subnet_group" "admin_db_group" {
   subnet_ids = var.subnet_ids
 
   tags = var.tags
+}
+
+resource "aws_db_parameter_group" "admin_db_parameter_group" {
+  name        = "${var.prefix}-db-parameter-group"
+  family      = "mysql5.7"
+  description = "Admin DB parameter group"
+
+  parameter {
+    name  = "sql_mode"
+    value = "STRICT_ALL_TABLES"
+  }
 }

--- a/modules/dhcp/mysql.tf
+++ b/modules/dhcp/mysql.tf
@@ -28,6 +28,8 @@ resource "aws_db_instance" "dhcp_server_db" {
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
 
+  parameter_group_name = aws_db_parameter_group.dhcp_db_parameter_group.name
+
   tags = var.tags
 }
 
@@ -36,4 +38,15 @@ resource "aws_db_subnet_group" "db" {
   subnet_ids = var.private_subnets
 
   tags = var.tags
+}
+
+resource "aws_db_parameter_group" "dhcp_db_parameter_group" {
+  name        = "${var.prefix}-db-parameter-group"
+  family      = "mysql5.7"
+  description = "DHCP DB parameter group"
+
+  parameter {
+    name  = "sql_mode"
+    value = "STRICT_ALL_TABLES"
+  }
 }


### PR DESCRIPTION
Without strict mode the server tries to proceed with the action when an error might have been a more secure choice. For example, by default MySQL will truncate data if it does not fit in a field, which can lead to unknown behaviour, or be leveraged by an attacker to circumvent data validation.