### PR TITLE
Remove unused DHCP leases db env vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,11 +193,6 @@ module "admin" {
   bind_config_bucket_key_arn           = module.dns.bind_config_bucket_key_arn
   dhcp_config_bucket_key_arn           = module.dhcp.dhcp_config_bucket_key_arn
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
-  dhcp_db_username                     = var.dhcp_db_username
-  dhcp_db_password                     = var.dhcp_db_password
-  dhcp_db_name                         = module.dhcp.db_name
-  dhcp_db_host                         = module.dhcp.db_host
-  dhcp_db_port                         = module.dhcp.db_port
   pdns_ips                             = var.pdns_ips
 
   depends_on = [

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -148,26 +148,6 @@ resource "aws_ecs_task_definition" "admin_task" {
           "value": "${var.bind_config_bucket_name}"
         },
         {
-          "name": "DHCP_DB_USER",
-          "value": "${var.dhcp_db_username}"
-        },
-        {
-          "name": "DHCP_DB_PASS",
-          "value": "${var.dhcp_db_password}"
-        },
-        {
-          "name": "DHCP_DB_NAME",
-          "value": "${var.dhcp_db_name}"
-        },
-        {
-          "name": "DHCP_DB_HOST",
-          "value": "${var.dhcp_db_host}"
-        },
-        {
-          "name": "DHCP_DB_PORT",
-          "value": "${var.dhcp_db_port}"
-        },
-        {
           "name": "PDNS_IPS",
           "value": "${var.pdns_ips}"
         },

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -121,26 +121,6 @@ variable "admin_local_development_domain_affix" {
   type = string
 }
 
-variable "dhcp_db_username" {
-  type = string
-}
-
-variable "dhcp_db_password" {
-  type = string
-}
-
-variable "dhcp_db_name" {
-  type = string
-}
-
-variable "dhcp_db_host" {
-  type = string
-}
-
-variable "dhcp_db_port" {
-  type = string
-}
-
 variable "pdns_ips" {
   type = string
 }


### PR DESCRIPTION
# What

Delete lease db variables being passed into the admin infra.

# Why

The leases db is no longer directly accessed from admin.

# Notes

**Admin [PR](https://github.com/ministryofjustice/staff-device-dns-dhcp-admin/pull/229) should be merged first**
