### PR TITLE
Define network ACL for DHCP VPC subnets

### DIFF
--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -17,6 +17,37 @@ resource "aws_security_group" "endpoints" {
   }
 }
 
+locals {
+  inbound_vpc_rules = [
+    {
+      "cidr_block": "0.0.0.0/0",
+      "from_port": 8000,
+      "protocol": "tcp",
+      "rule_action": "deny",
+      "rule_number": 100,
+      "to_port": 8000
+    }, {
+      "cidr_block": "0.0.0.0/0",
+      "from_port": 0,
+      "protocol": "-1",
+      "rule_action": "allow",
+      "rule_number": 200,
+      "to_port": 0
+    }
+  ]
+
+  outbound_vpc_rules = [
+    {
+      "cidr_block": "0.0.0.0/0",
+      "from_port": 0,
+      "protocol": "-1",
+      "rule_action": "allow",
+      "rule_number": 100,
+      "to_port": 0
+    }
+  ]
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "2.50.0"
@@ -40,6 +71,14 @@ module "vpc" {
   enable_rds_endpoint              = true
   rds_endpoint_private_dns_enabled = true
   rds_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
+
+  manage_default_network_acl = true
+  public_dedicated_network_acl = true
+  private_dedicated_network_acl = true
+  private_inbound_acl_rules = local.inbound_vpc_rules
+  private_outbound_acl_rules = local.outbound_vpc_rules
+  public_inbound_acl_rules = local.inbound_vpc_rules
+  public_outbound_acl_rules = local.outbound_vpc_rules
 
   enable_s3_endpoint = true
 

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -20,30 +20,30 @@ resource "aws_security_group" "endpoints" {
 locals {
   inbound_vpc_rules = [
     {
-      "cidr_block": "0.0.0.0/0",
-      "from_port": 8000,
-      "protocol": "tcp",
-      "rule_action": "deny",
-      "rule_number": 100,
-      "to_port": 8000
-    }, {
-      "cidr_block": "0.0.0.0/0",
-      "from_port": 0,
-      "protocol": "-1",
-      "rule_action": "allow",
-      "rule_number": 200,
-      "to_port": 0
+      "cidr_block" : "0.0.0.0/0",
+      "from_port" : 8000,
+      "protocol" : "tcp",
+      "rule_action" : "deny",
+      "rule_number" : 100,
+      "to_port" : 8000
+      }, {
+      "cidr_block" : "0.0.0.0/0",
+      "from_port" : 0,
+      "protocol" : "-1",
+      "rule_action" : "allow",
+      "rule_number" : 200,
+      "to_port" : 0
     }
   ]
 
   outbound_vpc_rules = [
     {
-      "cidr_block": "0.0.0.0/0",
-      "from_port": 0,
-      "protocol": "-1",
-      "rule_action": "allow",
-      "rule_number": 100,
-      "to_port": 0
+      "cidr_block" : "0.0.0.0/0",
+      "from_port" : 0,
+      "protocol" : "-1",
+      "rule_action" : "allow",
+      "rule_number" : 100,
+      "to_port" : 0
     }
   ]
 }
@@ -72,13 +72,13 @@ module "vpc" {
   rds_endpoint_private_dns_enabled = true
   rds_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
 
-  manage_default_network_acl = true
-  public_dedicated_network_acl = true
+  manage_default_network_acl    = true
+  public_dedicated_network_acl  = true
   private_dedicated_network_acl = true
-  private_inbound_acl_rules = local.inbound_vpc_rules
-  private_outbound_acl_rules = local.outbound_vpc_rules
-  public_inbound_acl_rules = local.inbound_vpc_rules
-  public_outbound_acl_rules = local.outbound_vpc_rules
+  private_inbound_acl_rules     = local.inbound_vpc_rules
+  private_outbound_acl_rules    = local.outbound_vpc_rules
+  public_inbound_acl_rules      = local.inbound_vpc_rules
+  public_outbound_acl_rules     = local.outbound_vpc_rules
 
   enable_s3_endpoint = true
 


### PR DESCRIPTION
We want to only allow known traffic on port 67 and 53 UDP and dissallow
port 8000 TCP.

This will prevent unauthorised access to the Kea API from the MoJ
network, while allowing the Admin to access it.