### PR TITLE
Allow private and public subnets to use VPC endpoints

### DIFF
--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -6,7 +6,7 @@ resource "aws_security_group" "endpoints" {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    cidr_blocks = [var.cidr_block]
   }
 
   egress {


### PR DESCRIPTION
Currently only services running in private subnets are allowed to use
the VPC endpoints. Public subnets using VPC endpoints will be blocked by
the security group. Change this to allow any subnet in the VPC to
communicate with the VPC endpoints.