### PR TITLE
Enable cross zone load balancing for DNS service

### DIFF
--- a/modules/dns/load_balancer.tf
+++ b/modules/dns/load_balancer.tf
@@ -2,6 +2,7 @@ resource "aws_lb" "load_balancer" {
   name               = var.prefix
   load_balancer_type = "network"
   internal           = true
+  enable_cross_zone_load_balancing = true
 
   subnet_mapping {
     subnet_id            = var.subnets[0]

--- a/modules/dns/load_balancer.tf
+++ b/modules/dns/load_balancer.tf
@@ -1,7 +1,7 @@
 resource "aws_lb" "load_balancer" {
-  name               = var.prefix
-  load_balancer_type = "network"
-  internal           = true
+  name                             = var.prefix
+  load_balancer_type               = "network"
+  internal                         = true
   enable_cross_zone_load_balancing = true
 
   subnet_mapping {


### PR DESCRIPTION
By default a multi AZ only distributes traffic to the AZ which is
associated with the IP being accessed.

For DNS, which is stateless, we want to distribute traffic to both AZs.
DHCP handles this at a higher level by distributing Primary and Standby
IPs.