### PR TITLE
Upgrade AWS provider and VPC module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ provider "tls" {
 }
 
 provider "aws" {
-  version = "~> 3.6"
+  version = "~> 3.10"
   alias   = "env"
   assume_role {
     role_arn = var.assume_role

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -59,7 +59,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.50.0"
+  version = "2.70.0"
   name    = "${var.prefix}-dns"
 
   cidr                 = var.cidr_block

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.50.0"
+  version = "2.70.0"
   name    = var.prefix
 
   cidr                 = var.cidr_block


### PR DESCRIPTION
AWS just introduced private link for S3:
https://aws.amazon.com/ru/blogs/aws/aws-privatelink-for-amazon-s3-now-available/

This currently breaks Terraform with the following error message:
Error: multiple VPC Endpoint Services matched; use additional constraints to reduce matches to a single VPC Endpoint Service

More on this issue here:
https://github.com/terraform-aws-modules/terraform-aws-vpc/issues/445

Tested that this upgrade doesn't force a rebuild of the infrastructure.