### PR TITLE
Pass metrics namespace to ECS task definition for Primary

### DIFF
--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -77,6 +77,10 @@ resource "aws_ecs_task_definition" "server_task" {
       {
         "name": "PUBLISH_METRICS",
         "value": "true"
+      },
+      {
+        "name": "METRICS_NAMESPACE",
+        "value": "${var.metrics_namespace}"
       }
     ],
     "image": "${module.dns_dhcp_common.ecr.repository_url}",


### PR DESCRIPTION
This metrics namespace is defined in 2 places and has potential to go
out of sync.

By passing the namespace to the task definition, it can be set
dynamically and the task can read this environment variable to find the
namespace to publish to.