### PR TITLE
Remove static IP from DHCP API load balancers

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,8 +28,6 @@ env:
     TF_VAR_transit_gateway_route_table_id: "/staff-device/dhcp/$ENV/transit_gateway_route_table_id"
     TF_VAR_dhcp_load_balancer_private_ip_eu_west_2a: "/staff-device/dhcp/$ENV/load_balancer_private_ip_eu_west_2a"
     TF_VAR_dhcp_load_balancer_private_ip_eu_west_2b: "/staff-device/dhcp/$ENV/load_balancer_private_ip_eu_west_2b"
-    TF_VAR_dhcp_api_load_balancer_private_ip_eu_west_2a: "/staff-device/dhcp/$ENV/load_balancer_api_private_ip_eu_west_2a"
-    TF_VAR_dhcp_api_load_balancer_private_ip_eu_west_2b: "/staff-device/dhcp/$ENV/load_balancer_api_private_ip_eu_west_2b"
     TF_VAR_dns_load_balancer_private_ip_eu_west_2a: "/staff-device/dns/$ENV/load_balancer_private_ip_eu_west_2a"
     TF_VAR_dns_load_balancer_private_ip_eu_west_2b: "/staff-device/dns/$ENV/load_balancer_private_ip_eu_west_2b"
     TF_VAR_sentry_dsn: "/staff-device/admin/sentry_dsn"

--- a/main.tf
+++ b/main.tf
@@ -121,22 +121,22 @@ locals {
 }
 
 module "dhcp" {
-  source                                       = "./modules/dhcp"
-  prefix                                       = module.dhcp_label.id
-  private_subnets                              = module.servers_vpc.private_subnets
-  tags                                         = module.dhcp_label.tags
-  vpc_id                                       = module.servers_vpc.vpc_id
-  dhcp_db_password                             = var.dhcp_db_password
-  dhcp_db_username                             = var.dhcp_db_username
-  load_balancer_private_ip_eu_west_2a          = var.dhcp_load_balancer_private_ip_eu_west_2a
-  load_balancer_private_ip_eu_west_2b          = var.dhcp_load_balancer_private_ip_eu_west_2b
-  vpn_hosted_zone_id                           = var.vpn_hosted_zone_id
-  vpn_hosted_zone_domain                       = var.vpn_hosted_zone_domain
-  short_prefix                                 = module.dhcp_label.stage # avoid 32 char limit on certain resources
-  is_publicly_accessible                       = local.publicly_accessible
-  vpc_cidr                                     = local.dns_dhcp_vpc_cidr
-  admin_local_development_domain_affix         = var.admin_local_development_domain_affix
-  metrics_namespace                            = local.metrics_namespace
+  source                               = "./modules/dhcp"
+  prefix                               = module.dhcp_label.id
+  private_subnets                      = module.servers_vpc.private_subnets
+  tags                                 = module.dhcp_label.tags
+  vpc_id                               = module.servers_vpc.vpc_id
+  dhcp_db_password                     = var.dhcp_db_password
+  dhcp_db_username                     = var.dhcp_db_username
+  load_balancer_private_ip_eu_west_2a  = var.dhcp_load_balancer_private_ip_eu_west_2a
+  load_balancer_private_ip_eu_west_2b  = var.dhcp_load_balancer_private_ip_eu_west_2b
+  vpn_hosted_zone_id                   = var.vpn_hosted_zone_id
+  vpn_hosted_zone_domain               = var.vpn_hosted_zone_domain
+  short_prefix                         = module.dhcp_label.stage # avoid 32 char limit on certain resources
+  is_publicly_accessible               = local.publicly_accessible
+  vpc_cidr                             = local.dns_dhcp_vpc_cidr
+  admin_local_development_domain_affix = var.admin_local_development_domain_affix
+  metrics_namespace                    = local.metrics_namespace
   dhcp_log_search_metric_filters = var.enable_dhcp_cloudwatch_log_metrics == true ? [
     "FATAL",
     "ERROR",

--- a/main.tf
+++ b/main.tf
@@ -130,8 +130,6 @@ module "dhcp" {
   dhcp_db_username                             = var.dhcp_db_username
   load_balancer_private_ip_eu_west_2a          = var.dhcp_load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b          = var.dhcp_load_balancer_private_ip_eu_west_2b
-  dhcp_api_load_balancer_private_ip_eu_west_2a = var.dhcp_api_load_balancer_private_ip_eu_west_2a
-  dhcp_api_load_balancer_private_ip_eu_west_2b = var.dhcp_api_load_balancer_private_ip_eu_west_2b
   vpn_hosted_zone_id                           = var.vpn_hosted_zone_id
   vpn_hosted_zone_domain                       = var.vpn_hosted_zone_domain
   short_prefix                                 = module.dhcp_label.stage # avoid 32 char limit on certain resources

--- a/modules/dhcp/http_api_load_balancer.tf
+++ b/modules/dhcp/http_api_load_balancer.tf
@@ -2,16 +2,8 @@ resource "aws_lb" "http_api_load_balancer" {
   name               = "${var.short_prefix}-dhcp-api"
   load_balancer_type = "network"
   internal           = true
+  subnets            = var.private_subnets
 
-  subnet_mapping {
-    subnet_id            = var.private_subnets[0]
-    private_ipv4_address = var.dhcp_api_load_balancer_private_ip_eu_west_2a
-  }
-
-  subnet_mapping {
-    subnet_id            = var.private_subnets[1]
-    private_ipv4_address = var.dhcp_api_load_balancer_private_ip_eu_west_2b
-  }
 
   enable_deletion_protection = false
 

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -61,11 +61,3 @@ variable "metrics_namespace" {
 variable "dhcp_log_search_metric_filters" {
   type = set(string)
 }
-
-variable "dhcp_api_load_balancer_private_ip_eu_west_2a" {
-  type = string
-}
-
-variable "dhcp_api_load_balancer_private_ip_eu_west_2b" {
-  type = string
-}

--- a/variables.tf
+++ b/variables.tf
@@ -83,14 +83,6 @@ variable "dns_load_balancer_private_ip_eu_west_2b" {
   type = string
 }
 
-variable "dhcp_api_load_balancer_private_ip_eu_west_2a" {
-  type = string
-}
-
-variable "dhcp_api_load_balancer_private_ip_eu_west_2b" {
-  type = string
-}
-
 variable "enable_corsham_test_bastion" {
   type    = bool
   default = true


### PR DESCRIPTION
Static IPs were added previously in order to make it troubleshooting easy during the Network ACL implementation.

Since we are no longer troubleshooting that, these APIs no longer need static IPs.