### PR TITLE
Run Kea API in multiple Availability Zones

### DIFF
--- a/modules/dhcp/ecs.tf
+++ b/modules/dhcp/ecs.tf
@@ -38,11 +38,11 @@ resource "aws_ecs_service" "service" {
 }
 
 resource "aws_ecs_service" "api_service" {
-  name            = "${var.prefix}-api-service"
-  cluster         = aws_ecs_cluster.server_cluster.id
-  task_definition = aws_ecs_task_definition.api_server_task.arn
-  desired_count   = "1"
-  launch_type     = "FARGATE"
+  name                             = "${var.prefix}-api-service"
+  cluster                          = aws_ecs_cluster.server_cluster.id
+  task_definition                  = aws_ecs_task_definition.api_server_task.arn
+  desired_count                    = "2"
+  launch_type                      = "FARGATE"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.http_api_target_group.arn
@@ -51,7 +51,10 @@ resource "aws_ecs_service" "api_service" {
   }
 
   network_configuration {
-    subnets = [var.private_subnets[0]]
+    subnets = [
+      var.private_subnets[0],
+      var.private_subnets[1]
+    ]
 
     security_groups = [
       aws_security_group.dhcp_server.id

--- a/modules/dhcp/ecs.tf
+++ b/modules/dhcp/ecs.tf
@@ -38,11 +38,11 @@ resource "aws_ecs_service" "service" {
 }
 
 resource "aws_ecs_service" "api_service" {
-  name                             = "${var.prefix}-api-service"
-  cluster                          = aws_ecs_cluster.server_cluster.id
-  task_definition                  = aws_ecs_task_definition.api_server_task.arn
-  desired_count                    = "2"
-  launch_type                      = "FARGATE"
+  name            = "${var.prefix}-api-service"
+  cluster         = aws_ecs_cluster.server_cluster.id
+  task_definition = aws_ecs_task_definition.api_server_task.arn
+  desired_count   = "2"
+  launch_type     = "FARGATE"
 
   load_balancer {
     target_group_arn = aws_lb_target_group.http_api_target_group.arn

--- a/modules/dhcp/http_api_load_balancer.tf
+++ b/modules/dhcp/http_api_load_balancer.tf
@@ -1,8 +1,9 @@
 resource "aws_lb" "http_api_load_balancer" {
-  name               = "${var.short_prefix}-dhcp-api"
-  load_balancer_type = "network"
-  internal           = true
-  subnets            = var.private_subnets
+  name                             = "${var.short_prefix}-dhcp-api"
+  load_balancer_type               = "network"
+  internal                         = true
+  subnets                          = var.private_subnets
+  enable_cross_zone_load_balancing = true
 
 
   enable_deletion_protection = false


### PR DESCRIPTION
Currently we only run one instance in one AZ, to improve the reliability
of the API, run it in multiple AZs