### PR TITLE
Move metrics namespace definition from a local to a variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -116,10 +116,6 @@ module "dhcp_standby" {
   ]
 }
 
-locals {
-  metrics_namespace = "Kea-DHCP"
-}
-
 module "dhcp" {
   source                               = "./modules/dhcp"
   prefix                               = module.dhcp_label.id
@@ -133,10 +129,10 @@ module "dhcp" {
   vpn_hosted_zone_id                   = var.vpn_hosted_zone_id
   vpn_hosted_zone_domain               = var.vpn_hosted_zone_domain
   short_prefix                         = module.dhcp_label.stage # avoid 32 char limit on certain resources
+  metrics_namespace                    = var.metrics_namespace
   is_publicly_accessible               = local.publicly_accessible
   vpc_cidr                             = local.dns_dhcp_vpc_cidr
   admin_local_development_domain_affix = var.admin_local_development_domain_affix
-  metrics_namespace                    = local.metrics_namespace
   dhcp_log_search_metric_filters = var.enable_dhcp_cloudwatch_log_metrics == true ? [
     "FATAL",
     "ERROR",

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,7 +22,7 @@ output "terraform_outputs" {
       ecs = module.admin.ecs
     }
 
-    metrics_namespace = local.metrics_namespace
+    metrics_namespace = var.metrics_namespace
 
     authentication = {
       cognito = {

--- a/variables.tf
+++ b/variables.tf
@@ -132,3 +132,8 @@ variable "enable_dhcp_cloudwatch_log_metrics" {
   type    = bool
   default = false
 }
+
+variable "metrics_namespace" {
+  type = string
+  default = "Kea-DHCP"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,6 @@ variable "enable_dhcp_cloudwatch_log_metrics" {
 }
 
 variable "metrics_namespace" {
-  type = string
+  type    = string
   default = "Kea-DHCP"
 }


### PR DESCRIPTION
This will allow publishing metrics to a custom namespace for your own
environment, instead of publishing to the Development namespace.

Example terraform.tfvars has been uploaded to SSM parameter store.