### PR TITLE
Allow bastion servers to be created in non-production

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -36,6 +36,7 @@ env:
     TF_VAR_corsham_vm_ip: "/staff-device/corsham_testing/corsham_vm_ip"
     TF_VAR_dhcp_egress_transit_gateway_routes: "/staff-device/$ENV/dhcp_egress_transit_gateway_routes"
     TF_VAR_byoip_pool_id: "/staff-device/dns/$ENV/public_ip_pool_id"
+    TF_VAR_enable_corsham_test_bastion: "/staff-device/dns-dhcp/$ENV/enable_bastion"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
 
 phases:

--- a/main.tf
+++ b/main.tf
@@ -258,7 +258,7 @@ module "corsham_test_bastion" {
     aws = aws.env
   }
 
-  count = terraform.workspace == "production" && var.enable_corsham_test_bastion == true ? 1 : 0
+  count = var.enable_corsham_test_bastion == true ? 1 : 0
 }
 
 module "dns_label" {

--- a/variables.tf
+++ b/variables.tf
@@ -85,7 +85,7 @@ variable "dns_load_balancer_private_ip_eu_west_2b" {
 
 variable "enable_corsham_test_bastion" {
   type    = bool
-  default = true
+  default = false
 }
 
 variable "admin_local_development_domain_affix" {


### PR DESCRIPTION
To access the wider network, we need a jump-box in the target VPC.
Specify whether to create the server in SSM parameter store, which can
be switched per environment.