### PR TITLE
Create routes to test VMs from public subnets

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -34,6 +34,7 @@ env:
     TF_VAR_bastion_allowed_ingress_ip: "/staff-device/corsham_testing/bastion_allowed_ingress_ip"
     TF_VAR_bastion_allowed_egress_ip: "/staff-device/corsham_testing/bastion_allowed_egress_ip"
     TF_VAR_corsham_vm_ip: "/staff-device/corsham_testing/corsham_vm_ip"
+    TF_VAR_model_office_vm_ip: "/staff-device/dns-dhcp/model_office_vm_ip"
     TF_VAR_dhcp_egress_transit_gateway_routes: "/staff-device/$ENV/dhcp_egress_transit_gateway_routes"
     TF_VAR_byoip_pool_id: "/staff-device/dns/$ENV/public_ip_pool_id"
     TF_VAR_enable_corsham_test_bastion: "/staff-device/dns-dhcp/$ENV/enable_bastion"

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,8 @@ module "servers_vpc" {
   tags                                   = module.dhcp_label.tags
   dhcp_transit_gateway_id                = var.dhcp_transit_gateway_id
   transit_gateway_route_table_id         = var.transit_gateway_route_table_id
+  corsham_vm_ip                          = var.corsham_vm_ip
+  model_office_vm_ip                     = var.model_office_vm_ip
 
   providers = {
     aws = aws.env

--- a/modules/servers_vpc/routes.tf
+++ b/modules/servers_vpc/routes.tf
@@ -81,3 +81,35 @@ resource "aws_route" "pdns-route-2a-pdns-2" {
     module.vpc
   ]
 }
+
+resource "aws_route" "model-office-testing-route" {
+  for_each = var.enable_dhcp_transit_gateway_attachment ? toset(module.vpc.public_route_table_ids) : []
+
+  route_table_id         = each.value
+  destination_cidr_block = "${var.model_office_vm_ip}/32"
+  transit_gateway_id     = var.dhcp_transit_gateway_id
+
+  timeouts {
+    create = "5m"
+  }
+
+  depends_on = [
+    module.vpc
+  ]
+}
+
+resource "aws_route" "corsham-testing-route" {
+  for_each = var.enable_dhcp_transit_gateway_attachment ? toset(module.vpc.public_route_table_ids) : []
+
+  route_table_id         = each.value
+  destination_cidr_block = "${var.corsham_vm_ip}/32"
+  transit_gateway_id     = var.dhcp_transit_gateway_id
+
+  timeouts {
+    create = "5m"
+  }
+
+  depends_on = [
+    module.vpc
+  ]
+}

--- a/modules/servers_vpc/variables.tf
+++ b/modules/servers_vpc/variables.tf
@@ -38,3 +38,11 @@ variable "dhcp_transit_gateway_id" {
 variable "transit_gateway_route_table_id" {
   type = string
 }
+
+variable "corsham_vm_ip" {
+  type = string
+}
+
+variable "model_office_vm_ip" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -124,6 +124,10 @@ variable "corsham_vm_ip" {
   type = string
 }
 
+variable "model_office_vm_ip" {
+  type = string
+}
+
 variable "byoip_pool_id" {
   type = string
 }


### PR DESCRIPTION
To gain access to the test VMs in Corsham and Model office, we have
to go through a jumpbox residing in our VPC.

The bastion server needs to be in a public subnet to allow SSH access to
it. The public subnets have an IGW as the default route.

Create explicit routes for Corsham and Model office to point to the
destination IPs.