### PR TITLE
Temporarily increase resources for pre-production

### DIFF
--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -1,6 +1,6 @@
 locals {
-  memory = terraform.workspace == "production" ? "4096" : "1024"
-  cpu    = terraform.workspace == "production" ? "2048" : "512"
+  memory = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
+  cpu    = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
 }
 
 resource "aws_ecs_task_definition" "server_task" {

--- a/modules/dhcp/mysql.tf
+++ b/modules/dhcp/mysql.tf
@@ -1,5 +1,5 @@
 locals {
-  is_production = terraform.workspace == "production" ? true : false
+  is_production = terraform.workspace == "production" || terraform.workspace == "pre-production" ? true : false
 }
 
 resource "aws_db_instance" "dhcp_server_db" {

--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -1,6 +1,6 @@
 locals {
-  memory = terraform.workspace == "production" ? "2048" : "1024"
-  cpu    = terraform.workspace == "production" ? "1024" : "512"
+  memory = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
+  cpu    = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
 }
 
 resource "aws_ecs_task_definition" "server_task" {


### PR DESCRIPTION
We will be testing on pre-production and need it to be exactly the same
as production. Increase the resources to run these tests.

This will be reversed when testing is done.