### PR TITLE
Enable metrics on the Standby KEA server

### DIFF
--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -76,7 +76,7 @@ resource "aws_ecs_task_definition" "server_task" {
       },
       {
         "name": "PUBLISH_METRICS",
-        "value": "false"
+        "value": "true"
       }
     ],
     "image": "${var.dhcp_repository_url}",


### PR DESCRIPTION
Both Primary and Standby Metrics will be displayed on Grafana