### PR TITLE
Define the metrics namespace for the standby server

### DIFF
--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -77,6 +77,10 @@ resource "aws_ecs_task_definition" "server_task" {
       {
         "name": "PUBLISH_METRICS",
         "value": "true"
+      },
+      {
+        "name": "METRICS_NAMESPACE",
+        "value": "${var.metrics_namespace}"
       }
     ],
     "image": "${var.dhcp_repository_url}",


### PR DESCRIPTION
This is required to get metrics onto Grafana for Standby