### PR TITLE
Add heartbeat subnet environment variable

### DIFF
--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -81,6 +81,10 @@ resource "aws_ecs_task_definition" "server_task" {
       {
         "name": "METRICS_NAMESPACE",
         "value": "${var.metrics_namespace}"
+      },
+      {
+        "name": "HEARTBEAT_SUBNET_ID",
+        "value": "2"
       }
     ],
     "image": "${module.dns_dhcp_common.ecr.repository_url}",

--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -81,6 +81,10 @@ resource "aws_ecs_task_definition" "server_task" {
       {
         "name": "METRICS_NAMESPACE",
         "value": "${var.metrics_namespace}"
+      },
+      {
+        "name": "HEARTBEAT_SUBNET_ID",
+        "value": "2"
       }
     ],
     "image": "${var.dhcp_repository_url}",


### PR DESCRIPTION
This will be used to supress sending subnet usage metrics metrics
generated by the heartbeat.