### PR TITLE
Publish heartbeat metrics to Grafana

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -275,6 +275,7 @@ module "heartbeat" {
   tags                                = module.dhcp_label.tags
   dhcp_ip                             = var.dhcp_load_balancer_private_ip_eu_west_2a
   hearbeat_instance_private_static_ip = var.hearbeat_instance_private_static_ip
+  metrics_namespace                   = var.metrics_namespace
 
   depends_on = [
     module.servers_vpc

--- a/modules/heartbeat/main.tf
+++ b/modules/heartbeat/main.tf
@@ -4,6 +4,19 @@ resource "aws_cloudwatch_log_group" "dhcp_heartbeat" {
   tags = var.tags
 }
 
+resource "aws_cloudwatch_log_metric_filter" "heartbeat_metrics_filter" {
+  name           = "heartbeat-failed"
+  pattern        = "\"received packets: 0\""
+  log_group_name = aws_cloudwatch_log_group.dhcp_heartbeat.name
+
+  metric_transformation {
+    name          = "heartbeat-failed"
+    namespace     = var.metrics_namespace
+    value         = "1"
+    default_value = "0"
+  }
+}
+
 data "template_file" "bootstrap" {
   template = file("${path.module}/boot_dhcp_client.sh")
   vars = {

--- a/modules/heartbeat/variables.tf
+++ b/modules/heartbeat/variables.tf
@@ -18,6 +18,10 @@ variable "dhcp_ip" {
   type = string
 }
 
+variable "metrics_namespace" {
+  type = string
+}
+
 variable "hearbeat_instance_private_static_ip" {
   type = string
 }


### PR DESCRIPTION
This creates a metric filter for failed leases from the heartbeat
instance.  This will be monitored in Grafana.