### PR TITLE
Fix heartbeat instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -275,7 +275,7 @@ module "heartbeat" {
   prefix                              = module.heartbeat_label.id
   subnets                             = module.servers_vpc.public_subnets
   vpc_id                              = module.servers_vpc.vpc_id
-  tags                                = module.dhcp_label.tags
+  tags                                = module.heartbeat_label.tags
   dhcp_ip                             = var.dhcp_load_balancer_private_ip_eu_west_2a
   hearbeat_instance_private_static_ip = var.hearbeat_instance_private_static_ip
   metrics_namespace                   = var.metrics_namespace

--- a/modules/heartbeat/boot_dhcp_client.sh
+++ b/modules/heartbeat/boot_dhcp_client.sh
@@ -36,6 +36,6 @@ EOF
 systemctl enable amazon-cloudwatch-agent.service && service amazon-cloudwatch-agent start
 
 while true; do
-  perfdhcp -4 ${dhcp_ip} -n5 -r1 -d3 -R5 | grep "received packets" >> ${log_file_path}
+  perfdhcp -4 ${dhcp_ip} -n2 -r1 -d3 -R50000 | grep "received packets" >> ${log_file_path}
   sleep 10;
 done

--- a/modules/heartbeat/main.tf
+++ b/modules/heartbeat/main.tf
@@ -31,7 +31,7 @@ data "aws_ami" "ubuntu_latest" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
   }
 
   owners = ["099720109477"] # Canonical


### PR DESCRIPTION
With the previous AMI search filter terraform was throwing error. Added amd64-server has fixed it.
Also passing the right label module to the heartbeat module to fix the tags.