### PR TITLE
Creates Route53 inbound resolvers with static IPs from this VPC

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -235,6 +235,8 @@ module "dns" {
   tags                                = module.dns_label.tags
   load_balancer_private_ip_eu_west_2a = var.dns_load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b = var.dns_load_balancer_private_ip_eu_west_2b
+  dns_route53_resolver_ip_eu_west_2a = var.dns_route53_resolver_ip_eu_west_2a
+  dns_route53_resolver_ip_eu_west_2b = var.dns_route53_resolver_ip_eu_west_2b
   vpc_id                              = module.servers_vpc.vpc_id
   vpc_cidr                            = local.dns_dhcp_vpc_cidr
   sentry_dsn                          = var.dns_sentry_dsn

--- a/modules/dns/route53_resolver.tf
+++ b/modules/dns/route53_resolver.tf
@@ -1,0 +1,20 @@
+resource "aws_route53_resolver_endpoint" "internal_hosted_zone" {
+  name      = "${var.prefix}-internal-hosted-zone-resolver-endpoint"
+  direction = "INBOUND"
+
+  security_group_ids = [
+    aws_security_group.resolver_endpoint.id,
+  ]
+
+  ip_address {
+    subnet_id = var.subnets[0]
+    ip = var.dns_route53_resolver_ip_eu_west_2a
+  }
+
+  ip_address {
+    subnet_id = var.subnets[1]
+    ip        = var.dns_route53_resolver_ip_eu_west_2b
+  }
+
+  tags = var.tags
+}

--- a/modules/dns/security_groups.tf
+++ b/modules/dns/security_groups.tf
@@ -45,3 +45,31 @@ resource "aws_security_group_rule" "dns_container_healthcheck_in" {
   security_group_id = aws_security_group.dns_server.id
   cidr_blocks       = [var.vpc_cidr]
 }
+
+resource "aws_security_group" "resolver_endpoint" {
+  name        = "${var.prefix}-resolver-endpoint"
+  description = "Allow the bind9 to talk to resolver endpoints"
+  vpc_id      = var.vpc_id
+
+  tags = var.tags
+}
+
+resource "aws_security_group_rule" "resolver_endpoint_dns_udp_in" {
+  description       = "Allow incoming dns udp traffic to resolver endpoint"
+  type              = "ingress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  security_group_id = aws_security_group.resolver_endpoint.id
+  cidr_blocks       = [var.vpc_cidr]
+}
+
+resource "aws_security_group_rule" "resolver_endpoint_dns_udp_out" {
+  description       = "Allow outging dns udp traffic from resolver endpoint"
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  security_group_id = aws_security_group.resolver_endpoint.id
+  cidr_blocks       = [var.vpc_cidr]
+}

--- a/modules/dns/security_groups.tf
+++ b/modules/dns/security_groups.tf
@@ -65,7 +65,7 @@ resource "aws_security_group_rule" "resolver_endpoint_dns_udp_in" {
 }
 
 resource "aws_security_group_rule" "resolver_endpoint_dns_udp_out" {
-  description       = "Allow outging dns udp traffic from resolver endpoint"
+  description       = "Allow outgoing dns udp traffic from resolver endpoint"
   type              = "egress"
   from_port         = 53
   to_port           = 53

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -33,3 +33,11 @@ variable "load_balancer_private_ip_eu_west_2b" {
 variable "sentry_dsn" {
   type = string
 }
+
+variable "dns_route53_resolver_ip_eu_west_2a" {
+  type = string
+}
+
+variable "dns_route53_resolver_ip_eu_west_2b" {
+  type = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,3 +34,7 @@ output "terraform_outputs" {
     }
   }
 }
+
+output "dns_dhcp_vpc_id" {
+  value = module.servers_vpc.vpc_id
+}

--- a/scripts/publish_terraform_outputs.sh
+++ b/scripts/publish_terraform_outputs.sh
@@ -9,3 +9,11 @@ aws ssm put-parameter --name "/terraform_dns_dhcp/$ENV/outputs" \
   --value "$terraform_outputs" \
   --type String \
   --overwrite
+
+  dns_dhcp_vpc_id=$(terraform output -json dns_dhcp_vpc_id)
+
+aws ssm put-parameter --name "/staff-device/dns-dhcp/$ENV/vpc-id" \
+  --description "VPC ID for Staff Device DNS DHCP" \
+  --value "$dns_dhcp_vpc_id" \
+  --type String \
+  --overwrite

--- a/variables.tf
+++ b/variables.tf
@@ -152,3 +152,11 @@ variable "metrics_namespace" {
   type    = string
   default = "Kea-DHCP"
 }
+
+variable "dns_route53_resolver_ip_eu_west_2a" {
+  type = string
+}
+
+variable "dns_route53_resolver_ip_eu_west_2b" {
+  type = string
+}


### PR DESCRIPTION
## What
Creates Route53 inbound resolvers with two static IPs from this VPC and publishes the VPC ID to Shared services SSM param store so that the Palo Alto can take the VPC id and attaches the Route 53 private zone with our VPC. 