### PR TITLE
update-terraform-outputs

### DIFF
--- a/scripts/publish_terraform_outputs.sh
+++ b/scripts/publish_terraform_outputs.sh
@@ -10,7 +10,7 @@ aws ssm put-parameter --name "/terraform_dns_dhcp/$ENV/outputs" \
   --type String \
   --overwrite
 
-  dns_dhcp_vpc_id=$(terraform output -json dns_dhcp_vpc_id)
+  dns_dhcp_vpc_id=$(terraform output dns_dhcp_vpc_id)
 
 aws ssm put-parameter --name "/staff-device/dns-dhcp/$ENV/vpc-id" \
   --description "VPC ID for Staff Device DNS DHCP" \


### PR DESCRIPTION
this update removes the " " (double quotation marks) from dns_dhcp_vpc_id output value.