### PR TITLE
Increasing max_connect_errors value.

### DIFF
--- a/modules/admin/db.tf
+++ b/modules/admin/db.tf
@@ -49,4 +49,8 @@ resource "aws_db_parameter_group" "admin_db_parameter_group" {
     name  = "sql_mode"
     value = "STRICT_ALL_TABLES"
   }
+  parameter {
+    name  = "max_connect_errors"
+    value = "10000"
+  }
 }


### PR DESCRIPTION
Increasing the maximum number of connection errors which are accepted before the connection is blocked as this does not appear to be an option that can be disabled.

More info in the issue [here](https://dsdmoj.atlassian.net/browse/PTTP-3048?atlOrigin=eyJpIjoiMzYyZmZkODc1NzY3NGMxYzliM2I0M2EwZDI4MGY0NjUiLCJwIjoiaiJ9).

![image](https://user-images.githubusercontent.com/21241593/114999119-78467380-9e99-11eb-82d6-11a9a00af14c.png)

Closes PTTP-3048.