### PR TITLE
Removing tag from VPC module blocks as they have built in tagging

### DIFF
--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -96,8 +96,6 @@ module "vpc" {
   logs_endpoint_private_dns_enabled = true
   logs_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
 
-  tags = var.tags
-
   azs = [
     "${var.region}a",
     "${var.region}b"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -7,7 +7,6 @@ module "vpc" {
   enable_nat_gateway   = true
   enable_dns_hostnames = true
   enable_dns_support   = true
-  tags                 = var.tags
 
   azs = [
     "${var.region}a",


### PR DESCRIPTION
AWS provided VPC module has a built in tagging and provided tag overwrites that.