### PR TITLE
:bricks: update ELB security group to allow a list of IP ranges

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -43,6 +43,7 @@ env:
     TF_VAR_dhcp_egress_transit_gateway_routes: "/staff-device/$ENV/dhcp_egress_transit_gateway_routes"
     TF_VAR_byoip_pool_id: "/staff-device/dns/$ENV/public_ip_pool_id"
     TF_VAR_enable_corsham_test_bastion: "/staff-device/dns-dhcp/$ENV/enable_bastion"
+    TF_VAR_allowed_ip_ranges: "/staff-device/dns-dhcp/admin/$ENV/allowed_ip_ranges"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
 phases:
   install:

--- a/main.tf
+++ b/main.tf
@@ -220,6 +220,7 @@ module "admin" {
   vpc_id                               = module.admin_vpc.vpc_id
   vpn_hosted_zone_domain               = var.vpn_hosted_zone_domain
   vpn_hosted_zone_id                   = var.vpn_hosted_zone_id
+  allowed_ip_ranges                    = var.allowed_ip_ranges
 
   depends_on = [
     module.admin_vpc

--- a/modules/admin/security_groups.tf
+++ b/modules/admin/security_groups.tf
@@ -17,7 +17,7 @@ resource "aws_security_group_rule" "admin_alb_in_from_web" {
   to_port           = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.admin_alb.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = var.allowed_ip_ranges
 }
 
 resource "aws_security_group_rule" "admin_alb_out" {

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -132,3 +132,7 @@ variable "dhcp_http_api_load_balancer_arn" {
 variable "private_zone" {
   type = string
 }
+
+variable "allowed_ip_ranges" {
+  type = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -164,3 +164,7 @@ variable "dns_route53_resolver_ip_eu_west_2b" {
 variable "dns_private_zone" {
   type = string
 }
+
+variable "allowed_ip_ranges" {
+  type = list(string)
+}


### PR DESCRIPTION
currently it allows "0.0.0.0/0"
the new allowed ip ranges list is maintained in Shared services AWS Parameter store secret in:
/staff-device/dns-dhcp/admin/`<ENV>`/allowed_ip_ranges

resolves ministryofjustice/cloud-operations#41