### PR TITLE
🧱 Terraform 1.1.8 Upgrade

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -48,7 +48,7 @@ env:
 phases:
   install:
     commands:
-      - wget --no-verbose -O terraform.zip https://releases.hashicorp.com/terraform/0.14.0/terraform_0.14.0_linux_amd64.zip
+      - wget --no-verbose -O terraform.zip https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip
       - unzip terraform.zip
       - mv terraform /bin
 

--- a/modules/authentication/main.tf
+++ b/modules/authentication/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 locals {
   enabled = var.enable_authentication ? 1 : 0
 }

--- a/modules/corsham_test/bastion.tf
+++ b/modules/corsham_test/bastion.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 resource "aws_instance" "corsham_testing_bastion" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = "t2.nano"

--- a/modules/dhcp_standby/ecs.tf
+++ b/modules/dhcp_standby/ecs.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 resource "aws_ecs_service" "service" {
   name            = "${var.prefix}-service"
   cluster         = var.dhcp_server_cluster_id

--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 module "dns_dhcp_common" {
   source = "../dns_dhcp_common"
   prefix = var.prefix

--- a/modules/dns_dhcp_common/ecr.tf
+++ b/modules/dns_dhcp_common/ecr.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 resource "aws_ecr_repository" "docker_repository" {
   name                 = var.prefix
   image_tag_mutability = "MUTABLE"

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 resource "aws_security_group" "endpoints" {
   name   = "${var.prefix}-endpoints"
   tags   = var.tags

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,6 +1,15 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.70.0"
+  version = "3.14.0"
   name    = var.prefix
 
   cidr                 = var.cidr_block

--- a/modules/vpc_flow_logs/main.tf
+++ b/modules/vpc_flow_logs/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.75.0"
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {}
 
 resource "aws_flow_log" "vpc" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.1.0"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
This PR builds on the [previous](https://github.com/ministryofjustice/staff-device-dns-dhcp-infrastructure/commit/bd137aef3320adff55cd57e9f2eda50b783a068a) upgrade from 0.13 to 0.14. 

In this PR the `aws` provider is added where required and any required terraform versions are updated to v1.1.8. 