### PR TITLE
:recycle: Refactor AWS VPC module dependencies

### DIFF
--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -1,0 +1,73 @@
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+
+  tags = var.tags
+
+  depends_on = [aws_security_group.endpoints]
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+
+  tags = var.tags
+
+  depends_on = [aws_security_group.endpoints]
+}
+
+resource "aws_vpc_endpoint" "cloudwatch_logs" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.logs"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+
+  tags = var.tags
+
+  depends_on = [aws_security_group.endpoints]
+}
+
+resource "aws_vpc_endpoint" "rds" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.rds"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+
+  tags = var.tags
+
+  depends_on = [aws_security_group.endpoints]
+}
+
+resource "aws_vpc_endpoint" "monitoring" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.monitoring"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+
+  tags = var.tags
+
+  depends_on = [aws_security_group.endpoints]
+}
+
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id          = module.vpc.vpc_id
+  route_table_ids = module.vpc.private_route_table_ids
+  service_name    = "com.amazonaws.${var.region}.s3"
+
+  tags = var.tags
+}

--- a/modules/servers_vpc/main.tf
+++ b/modules/servers_vpc/main.tf
@@ -69,27 +69,12 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.70.0"
+  version = "3.14.0"
   name    = "${var.prefix}-dns"
 
   cidr                 = var.cidr_block
   enable_dns_hostnames = true
   enable_dns_support   = true
-
-  ecr_api_endpoint_private_dns_enabled = true
-  ecr_api_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
-  ecr_dkr_endpoint_private_dns_enabled = true
-  ecr_dkr_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
-  enable_ecr_api_endpoint              = true
-  enable_ecr_dkr_endpoint              = true
-
-  enable_monitoring_endpoint              = true
-  monitoring_endpoint_private_dns_enabled = true
-  monitoring_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
-
-  enable_rds_endpoint              = true
-  rds_endpoint_private_dns_enabled = true
-  rds_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
 
   manage_default_network_acl    = true
   private_dedicated_network_acl = true
@@ -98,12 +83,6 @@ module "vpc" {
   public_dedicated_network_acl  = true
   public_inbound_acl_rules      = local.inbound_vpc_rules
   public_outbound_acl_rules     = local.outbound_vpc_rules
-
-  enable_s3_endpoint = true
-
-  enable_logs_endpoint              = true
-  logs_endpoint_private_dns_enabled = true
-  logs_endpoint_security_group_ids  = [aws_security_group.endpoints.id]
 
   azs = [
     "${var.region}a",


### PR DESCRIPTION
Manuually creating all the VPC endpoints, this is required due to the AWS VPC module upgrade which no longer has the original inputs.