### PR TITLE
:bug: remove double quotes from the VPC id value

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.75.0"
-  constraints = ">= 3.10.0, 3.75.0, ~> 3.75"
+  constraints = ">= 3.63.0, 3.75.0"
   hashes = [
     "h1:TgB2G/9/RePrVXq2iGo+/BCCmUQK2nRuvTeAa1geiIk=",
+    "h1:svxtwlFr9HWekKE6/KJtZL+hTEu2qf/YlfRK4IDbsXw=",
     "zh:082cf60b79abb20ca1b8314bf88c1e00d79aa7534dc7cfc4434d96dee82c2ed6",
     "zh:11ea608d2c6757df8b76af50a25d5b050f029ed32dcbea1e2477e3701d73f8d5",
     "zh:3ff1ca4fa5033cf8ecbe64482c22009196882ec8cf74aa107389690839cfe7fa",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = "2.2.2"
   hashes = [
     "h1:5UYW2wJ320IggrzLt8tLD6MowePqycWtH1b2RInHZkE=",
+    "h1:SjDyZXIUHEQzZe10VjhlhZq2a9kgQB6tmqJcpq2BeWg=",
     "zh:027e4873c69da214e2fed131666d5de92089732a11d096b68257da54d30b6f9d",
     "zh:0ba2216e16cfb72538d76a4c4945b4567a76f7edbfef926b1c5a08d7bba2a043",
     "zh:1fee8f6aae1833c27caa96e156cf99a681b6f085e476d7e1b77d285e21d182c1",
@@ -44,6 +46,7 @@ provider "registry.terraform.io/hashicorp/template" {
   version     = "2.2.0"
   constraints = "~> 2.2"
   hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
     "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
@@ -62,6 +65,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "3.3.0"
   constraints = "~> 3.3"
   hashes = [
+    "h1:A4xOtHhD4jCmn4nO1xCTk2Nl5IP5JpjicjF+Fuu2ZFQ=",
     "h1:xx/b39Q9FVZSlDc97rlDmQ9dNaaxFFyVzP9kV+47z28=",
     "zh:16140e8cc880f95b642b6bf6564f4e98760e9991864aacc8e21273423571e561",
     "zh:16338b8457759c97fdd73153965d6063b037f2954fd512e569fcdc42b7fef743",
@@ -83,6 +87,7 @@ provider "registry.terraform.io/terraform-providers/mysql" {
   constraints = "~> 1.9"
   hashes = [
     "h1:qC9l8/oK2HcOcSqc3QnHpWjE6U5wfZq4trk37TYjdco=",
+    "h1:xCQLVKy18oE/Wo3IkK82GzRX+sEioMyPFUlRt28USiA=",
     "zh:2dbd3d607e99ef16d0e177cccf2dc570e165d8b2d6a2902db7c62ce831948301",
     "zh:34bf5a491cb015f513305b8c15e75c64d4bcde164f7f061140899a1bb5042d37",
     "zh:4814e797ebd54598ce20444951793a1d4a78c2260335f0e229441d276823664d",

--- a/scripts/publish_terraform_outputs.sh
+++ b/scripts/publish_terraform_outputs.sh
@@ -10,10 +10,10 @@ aws ssm put-parameter --name "/terraform_dns_dhcp/$ENV/outputs" \
   --type String \
   --overwrite
 
-  dns_dhcp_vpc_id=$(terraform output dns_dhcp_vpc_id)
+  dns_dhcp_vpc_id=$(terraform output --raw dns_dhcp_vpc_id)
 
 aws ssm put-parameter --name "/staff-device/dns-dhcp/$ENV/vpc-id" \
   --description "VPC ID for Staff Device DNS DHCP" \
-  --value "$dns_dhcp_vpc_id" \
+  --value $dns_dhcp_vpc_id \
   --type String \
   --overwrite


### PR DESCRIPTION
these double quotes were store as additional caracters in the parameter store and then it was causing the private-dns-zone pipeline to fail. Closes ministryofjustice/staff-device-private-dns-zone#12