### PR TITLE
:wheelchair: make db instances publicly inaccessible

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,14 +14,13 @@ provider "mysql" {
 
 provider "aws" {
 
-  alias   = "env"
+  alias = "env"
   assume_role {
     role_arn = var.assume_role
   }
 }
 
 locals {
-  publicly_accessible = terraform.workspace == "production" ? false : true
   dhcp_log_metrics = [
     "FATAL",
     "ERROR",
@@ -146,7 +145,6 @@ module "dhcp" {
   dhcp_db_password                     = var.dhcp_db_password
   dhcp_db_username                     = var.dhcp_db_username
   dhcp_log_search_metric_filters       = var.enable_dhcp_cloudwatch_log_metrics == true ? local.dhcp_log_metrics : []
-  is_publicly_accessible               = local.publicly_accessible
   load_balancer_private_ip_eu_west_2a  = var.dhcp_load_balancer_private_ip_eu_west_2a
   load_balancer_private_ip_eu_west_2b  = var.dhcp_load_balancer_private_ip_eu_west_2b
   metrics_namespace                    = var.metrics_namespace
@@ -190,7 +188,6 @@ module "admin" {
   dhcp_service_name                    = module.dhcp.ecs.service_name
   dns_cluster_name                     = module.dns.ecs.cluster_name
   dns_service_name                     = module.dns.ecs.service_name
-  is_publicly_accessible               = local.publicly_accessible
   kea_config_bucket_arn                = module.dhcp.kea_config_bucket_arn
   kea_config_bucket_name               = module.dhcp.kea_config_bucket_name
   pdns_ips                             = var.pdns_ips

--- a/modules/admin/db.tf
+++ b/modules/admin/db.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "admin_db" {
   monitoring_interval         = 60
   skip_final_snapshot         = true
   deletion_protection         = local.is_production ? true : false
-  publicly_accessible         = var.is_publicly_accessible
+  publicly_accessible         = false
 
   enabled_cloudwatch_logs_exports = ["audit", "error", "general", "slowquery"]
 

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -105,10 +105,6 @@ variable "bind_config_bucket_arn" {
   type = string
 }
 
-variable "is_publicly_accessible" {
-  type = bool
-}
-
 variable "dhcp_config_bucket_key_arn" {
   type = string
 }

--- a/modules/dhcp/mysql.tf
+++ b/modules/dhcp/mysql.tf
@@ -19,7 +19,7 @@ resource "aws_db_instance" "dhcp_server_db" {
   multi_az                    = true
   name                        = replace(var.prefix, "-", "")
   password                    = var.dhcp_db_password
-  publicly_accessible         = var.is_publicly_accessible
+  publicly_accessible         = false
   skip_final_snapshot         = true
   storage_encrypted           = true
   storage_type                = "gp2"

--- a/modules/dhcp/variables.tf
+++ b/modules/dhcp/variables.tf
@@ -46,10 +46,6 @@ variable "short_prefix" {
   type = string
 }
 
-variable "is_publicly_accessible" {
-  type = bool
-}
-
 variable "admin_local_development_domain_affix" {
   type = string
 }

--- a/modules/dns_dhcp_common/iam.tf
+++ b/modules/dns_dhcp_common/iam.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role" "ecs_task_role" {
 }
 
 resource "aws_iam_role" "ecs_execution_role" {
-  name               = "${var.prefix}-ecs-execution-role"
+  name = "${var.prefix}-ecs-execution-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/versions.tf
+++ b/versions.tf
@@ -2,23 +2,23 @@ terraform {
   required_version = ">= 1.1.0"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.75.0"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
       version = "2.2.2"
     }
     mysql = {
-      source = "terraform-providers/mysql"
-      version  = "~> 1.9"
+      source  = "terraform-providers/mysql"
+      version = "~> 1.9"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
       version = "~> 2.2"
     }
     tls = {
-      source = "hashicorp/tls"
+      source  = "hashicorp/tls"
       version = "~> 3.3"
     }
   }


### PR DESCRIPTION
Closes ministryofjustice/cloud-operations#69

This has been done as part of the recommendations from the AWS Trusted advisors. Also RDS in non-production environments were given public accessibility for debugging. The service is now live. And public access to RDS is no longer needed.