### PR TITLE
:wrench: set rds parameter log_bin_trust

### DIFF
--- a/modules/dhcp/mysql.tf
+++ b/modules/dhcp/mysql.tf
@@ -49,4 +49,9 @@ resource "aws_db_parameter_group" "dhcp_db_parameter_group" {
     name  = "sql_mode"
     value = "STRICT_ALL_TABLES"
   }
+
+  parameter {
+    name  = "log_bin_trust_function_creators"
+    value = "1"
+  }
 }


### PR DESCRIPTION
This is parameter is needed for kea primary server to change or grant permissions on the database