### PR TITLE
:wrench: Increase CPU and Memory

### DIFF
--- a/modules/dhcp/ecs_task_definition_api.tf
+++ b/modules/dhcp/ecs_task_definition_api.tf
@@ -3,8 +3,8 @@ resource "aws_ecs_task_definition" "api_server_task" {
   task_role_arn            = module.dns_dhcp_common.iam.ecs_task_role_arn
   execution_role_arn       = module.dns_dhcp_common.iam.ecs_execution_role_arn
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "512"
-  memory                   = "1024"
+  cpu                      = "1024"
+  memory                   = "2048"
   network_mode             = "awsvpc"
 
   container_definitions = <<EOF


### PR DESCRIPTION
Increasing CPU from 512 -> 1024, this necessitates the memory be doubled as well.

Notes [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html).