### PR TITLE
map TCP port 53 with host for DNS server container

### DIFF
--- a/modules/dns/ecs_task_definition.tf
+++ b/modules/dns/ecs_task_definition.tf
@@ -15,6 +15,11 @@ resource "aws_ecs_task_definition" "server_task" {
         "hostPort": 53,
         "containerPort": 53,
         "protocol": "udp"
+      },
+      {
+        "hostPort": 53,
+        "containerPort": 53,
+        "protocol": "tcp"
       }
     ],
     "essential": true,


### PR DESCRIPTION
DNS server container image has already been modified to expose port 53 on TCP