### PR TITLE
:wrench: Disable ECS auto-assign public IP addresses

### DIFF
--- a/modules/dhcp/ecs.tf
+++ b/modules/dhcp/ecs.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_service" "service" {
       aws_security_group.dhcp_server.id
     ]
 
-    assign_public_ip = true
+    assign_public_ip = false
   }
 }
 
@@ -64,6 +64,6 @@ resource "aws_ecs_service" "api_service" {
       aws_security_group.dhcp_server.id
     ]
 
-    assign_public_ip = true
+    assign_public_ip = false
   }
 }

--- a/modules/dns/ecs.tf
+++ b/modules/dns/ecs.tf
@@ -30,6 +30,6 @@ resource "aws_ecs_service" "service" {
       aws_security_group.dns_server.id
     ]
 
-    assign_public_ip = true
+    assign_public_ip = false
   }
 }


### PR DESCRIPTION
Set `assign_public_ip = false` on both DNS and DHCP ECS tasks. This is to test if this is required in Pre-Prod, prior to moving into Prod. Related to [this ](https://github.com/ministryofjustice/nvvs-devops/issues/60)TA ticket.