### PR TITLE
 increasing DNS ECS task count maximum from 6 to 12

### DIFF
--- a/modules/dns/ecs_auto_scaling.tf
+++ b/modules/dns/ecs_auto_scaling.tf
@@ -1,7 +1,7 @@
 resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.server_cluster.name}/${aws_ecs_service.service.name}"
-  max_capacity       = 6
+  max_capacity       = 12
   min_capacity       = 2
   scalable_dimension = "ecs:service:DesiredCount"
 }


### PR DESCRIPTION
As agreed, This PR will increase the maximum ECS task count for DNS from 6 to 12 