### PR TITLE
Updated tags to be inline with MOJ polices 

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,6 @@ env:
   variables:
     #TF_IN_AUTOMATION: true
     TF_INPUT: 0
-    TF_VAR_owner_email: staff-device-dns-dhcp@justice.gov.uk
     TF_VAR_env: ${ENV}
     TF_VAR_enable_critical_notifications: true
     TF_VAR_enable_authentication: true

--- a/main.tf
+++ b/main.tf
@@ -41,26 +41,31 @@ locals {
 module "dhcp_label" {
   source       = "./modules/label"
   service_name = "dhcp"
+  owner_email = var.owner_email
 }
 
 module "dhcp_standby_label" {
   source       = "./modules/label"
   service_name = "dhcp-standby"
+  owner_email = var.owner_email
 }
 
 module "heartbeat_label" {
   source       = "./modules/label"
   service_name = "dns-dhcp-heartbeat"
+  owner_email = var.owner_email
 }
 
 module "admin_label" {
   source       = "./modules/label"
   service_name = "admin"
+  owner_email = var.owner_email
 }
 
 module "auth_label" {
   source       = "./modules/label"
   service_name = "auth"
+  owner_email = var.owner_email
 }
 
 data "aws_region" "current_region" {}
@@ -283,6 +288,7 @@ module "corsham_test_bastion" {
 module "dns_label" {
   source       = "./modules/label"
   service_name = "dns"
+  owner_email = var.owner_email
 }
 
 module "dhcp_dns_vpc_flow_logs" {

--- a/main.tf
+++ b/main.tf
@@ -41,31 +41,31 @@ locals {
 module "dhcp_label" {
   source       = "./modules/label"
   service_name = "dhcp"
-  owner_email = var.owner_email
+  owner_email  = var.owner_email
 }
 
 module "dhcp_standby_label" {
   source       = "./modules/label"
   service_name = "dhcp-standby"
-  owner_email = var.owner_email
+  owner_email  = var.owner_email
 }
 
 module "heartbeat_label" {
   source       = "./modules/label"
   service_name = "dns-dhcp-heartbeat"
-  owner_email = var.owner_email
+  owner_email  = var.owner_email
 }
 
 module "admin_label" {
   source       = "./modules/label"
   service_name = "admin"
-  owner_email = var.owner_email
+  owner_email  = var.owner_email
 }
 
 module "auth_label" {
   source       = "./modules/label"
   service_name = "auth"
-  owner_email = var.owner_email
+  owner_email  = var.owner_email
 }
 
 data "aws_region" "current_region" {}
@@ -288,7 +288,7 @@ module "corsham_test_bastion" {
 module "dns_label" {
   source       = "./modules/label"
   service_name = "dns"
-  owner_email = var.owner_email
+  owner_email  = var.owner_email
 }
 
 module "dhcp_dns_vpc_flow_logs" {

--- a/modules/label/main.tf
+++ b/modules/label/main.tf
@@ -7,13 +7,17 @@ module "label" {
   name      = var.service_name
   delimiter = "-"
 
+local{
+ is_production = "${terraform.workspace == "production" ? "true" : "false"}"
+}
+
   tags = {
     "business-unit" = "HQ"
     "application"   = "dhcp-dns",
-    "is-production" = "true"
-    "owner"         = "NVVS DevOps Team https://ministryofjustice.github.io/nvvs-devops"
+    "is-production" = tostring(local.is_production)
+    "owner"         = "NVVS DevOps Team:${var.owner_email}"
 
-    "environment-name" = "global"
+    "environment-name" = terraform.workspace.environment
     "source-code"      = "https://github.com/ministryofjustice/staff-device-dns-dhcp-infrastructure"
   }
 }

--- a/modules/label/main.tf
+++ b/modules/label/main.tf
@@ -1,3 +1,7 @@
+locals {
+  is_production = terraform.workspace == "production" ? true : false
+}
+
 module "label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
@@ -7,17 +11,13 @@ module "label" {
   name      = var.service_name
   delimiter = "-"
 
-local{
- is_production = "${terraform.workspace == "production" ? "true" : "false"}"
-}
-
   tags = {
     "business-unit" = "HQ"
     "application"   = "dhcp-dns",
     "is-production" = tostring(local.is_production)
     "owner"         = "NVVS DevOps Team:${var.owner_email}"
 
-    "environment-name" = terraform.workspace.environment
+    "environment-name" = terraform.workspace
     "source-code"      = "https://github.com/ministryofjustice/staff-device-dns-dhcp-infrastructure"
   }
 }

--- a/modules/label/variables.tf
+++ b/modules/label/variables.tf
@@ -1,3 +1,7 @@
 variable "service_name" {
   type = string
 }
+
+variable "owner_email" {
+  type = string
+}

--- a/scripts/generate-env-file.sh
+++ b/scripts/generate-env-file.sh
@@ -77,10 +77,6 @@ export TF_VAR_env=${ENV}
 
 ## This value has been applied to the envs via AWS CodePipeline CI.
 ## We don't want to use the default variable's value here.
-export TF_VAR_owner_email=staff-device-dns-dhcp@justice.gov.uk
-
-## This value has been applied to the envs via AWS CodePipeline CI.
-## We don't want to use the default variable's value here.
 export TF_VAR_enable_critical_notifications=true
 
 ## This value has been applied to the envs via AWS CodePipeline CI.

--- a/scripts/generate-github-env.sh
+++ b/scripts/generate-github-env.sh
@@ -10,10 +10,6 @@ SCRIPT_PATH="${SCRIPT_DIR}/aws_ssm_get_parameters.sh"
 
 ## This value has been applied to the envs via AWS CodePipeline CI.
 ## We don't want to use the default variable's value here.
-echo "TF_VAR_owner_email=staff-device-dns-dhcp@justice.gov.uk" >> $GITHUB_ENV
-
-## This value has been applied to the envs via AWS CodePipeline CI.
-## We don't want to use the default variable's value here.
 echo "TF_VAR_enable_critical_notifications=true" >> $GITHUB_ENV
 
 ## This value has been applied to the envs via AWS CodePipeline CI.

--- a/variables.tf
+++ b/variables.tf
@@ -182,3 +182,8 @@ variable "api_basic_auth_password" {
 variable "shared_services_account_id" {
   type = string
 }
+
+variable "owner_email" {
+  type    = string
+  default = "lanwifi-devops@digital.justice.gov.uk"
+}


### PR DESCRIPTION
MOJ tagging policy: https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html#mandatory

Change 1
__________________________________________
is_production is currently referenced in many places of the code base.
by centralising it to the label module we will reduce the amount of
times its referenced. This works as long as we follow the Terraform
workspace naming convention of production, pre-production and
development.

Change 2
__________________________________________
Previously the owner email was not defined in the tags, as per MOJ
mandatory tags documentation:
https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html#mandatory
We need to have the owner email set.

During the refactoring process, we found that the owner_email was also
set incorrectly in the buildspec files, we have removed this value from
these file and set them within the terraform instead.