### PR TITLE
Added a space in label module for owner tag

### DIFF
--- a/modules/label/main.tf
+++ b/modules/label/main.tf
@@ -15,7 +15,7 @@ module "label" {
     "business-unit" = "HQ"
     "application"   = "dhcp-dns",
     "is-production" = tostring(local.is_production)
-    "owner"         = "NVVS DevOps Team:${var.owner_email}"
+    "owner"         = "NVVS DevOps Team: ${var.owner_email}"
 
     "environment-name" = terraform.workspace
     "source-code"      = "https://github.com/ministryofjustice/staff-device-dns-dhcp-infrastructure"


### PR DESCRIPTION
After re-reviewing the MOJ tag policy, it was identified that there is a
space, between owner NAME & EMAIL. This was hard to spot orignally, due
to text wrapping on the policy page.