### PR TITLE
Added in new jumpbox module

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -45,6 +45,13 @@ provider "registry.terraform.io/hashicorp/local" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:sZ7MTSD4FLekNN2wSNFGpM+5slfvpm5A/NLVZiB7CO0=",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/template" {
   version     = "2.2.0"
   constraints = "~> 2.2"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,6 +42,7 @@ env:
     TF_VAR_dhcp_egress_transit_gateway_routes: "/staff-device/$ENV/dhcp_egress_transit_gateway_routes"
     TF_VAR_byoip_pool_id: "/staff-device/dns/$ENV/public_ip_pool_id"
     TF_VAR_enable_corsham_test_bastion: "/staff-device/dns-dhcp/$ENV/enable_bastion"
+    TF_VAR_enable_bastion_jumpbox: "/staff-device/dns-dhcp/$ENV/enable_bastion_jumpbox"
     TF_VAR_allowed_ip_ranges: "/staff-device/dns-dhcp/admin/$ENV/allowed_ip_ranges"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
     TF_VAR_api_basic_auth_username: "/codebuild/dhcp/admin/api/basic_auth_username"

--- a/main.tf
+++ b/main.tf
@@ -262,6 +262,30 @@ module "dns" {
   }
 }
 
+module "bastion_label" {
+  source        = "./modules/label"
+  service_name  = "dns-bastion"
+  owner_email   = var.owner_email
+}
+
+module "bastion" {
+  source          = "./modules/bastion"
+  prefix          = module.bastion_label.id
+  vpc_id          = module.servers_vpc.vpc.vpc_id
+  vpc_cidr_block  = module.servers_vpc.vpc.vpc_cidr_block
+  private_subnets = module.servers_vpc.vpc.private_subnets
+  //bastion_allowed_ingress_ip = var.bastion_allowed_ingress_ip
+  tags = module.bastion_label.tags
+
+  providers = {
+    aws = aws.env
+  }
+
+  depends_on = [module.servers_vpc]
+
+  count = var.enable_bastion_jumpbox == true ? 1 : 0
+}
+
 module "corsham_test_bastion" {
   source = "./modules/corsham_test"
 
@@ -284,6 +308,7 @@ module "corsham_test_bastion" {
 
   count = var.enable_corsham_test_bastion == true ? 1 : 0
 }
+
 
 module "dns_label" {
   source       = "./modules/label"

--- a/main.tf
+++ b/main.tf
@@ -263,9 +263,9 @@ module "dns" {
 }
 
 module "bastion_label" {
-  source        = "./modules/label"
-  service_name  = "dns-bastion"
-  owner_email   = var.owner_email
+  source       = "./modules/label"
+  service_name = "dns-bastion"
+  owner_email  = var.owner_email
 }
 
 module "bastion" {

--- a/modules/bastion/README.md
+++ b/modules/bastion/README.md
@@ -1,0 +1,55 @@
+# SSM Bastion Access
+
+This bastion is not accessible via the public internet, it does not have a public ip. To connect to it one must use the SSM Session Manager.
+
+## Prerequisites
+
+- aws cli
+- [Session Manager plugin for the AWS CLI][plugin]
+
+On a Mac install the Session Manager plugin with [Homebrew][brew]
+
+```shell
+brew install --cask session-manager-plugin
+```
+
+## Connection from terminal
+
+You will need the `instance id` of the bastion EC2 instance - this useful command will return a table of instances
+
+```shell
+export AWS_PROFILE=the_awsprofile_name
+```
+
+```shell
+
+aws --profile ${AWS_PROFILE} \
+ec2 describe-instances \
+--query 'Reservations[].Instances[].[InstanceId,InstanceType,PublicIpAddress,Tags[?Key==`Name`]| [0].Value]' \
+--output table
+
+```
+
+Example result
+
+```shell
+---------------------------------------------------------------------------------------------------------------
+|                                              DescribeInstances                                              |
++---------------------+--------------+-----------------+------------------------------------------------------+
+|  i-0199asds08e827733|  t3.xlarge   |  1.2.3.4        |  MOJ-AW2-PAN01A                                      |
+|  i-074571ddc6dddddcc|  t2.micro    |  1.3.2.51       |  None                                                |
+|  i-0c4tttbbbb31fd3e6|  t2.nano     |  None           |  staff-infrastructure-development-net-svc-bastion    |
++---------------------+--------------+-----------------+------------------------------------------------------+
+
+```
+
+Grab the id and run the following command
+
+```shell
+aws --profile ${AWS_PROFILE} ssm start-session --target i-0c4tttbbbb31fd3e6
+```
+
+Now you will be logged in.
+
+[plugin]: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+[brew]: https://brew.sh/

--- a/modules/bastion/bastion.tf
+++ b/modules/bastion/bastion.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.14.0"
+    }
+  }
+}
+
+resource "aws_instance" "bastion" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3a.small"
+
+  vpc_security_group_ids = [
+    aws_security_group.bastion.id
+  ]
+
+
+
+  subnet_id                            = var.private_subnets[0]
+  monitoring                           = true
+  associate_public_ip_address          = false
+  iam_instance_profile                 = aws_iam_instance_profile.this.id
+  instance_initiated_shutdown_behavior = "terminate"
+  tags                                 = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}

--- a/modules/bastion/iam.tf
+++ b/modules/bastion/iam.tf
@@ -1,0 +1,51 @@
+data "aws_iam_policy_document" "trust_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "ec2.amazonaws.com",
+        "ssm.amazonaws.com",
+      ]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "iam_instance_role" {
+  name               = local.name
+  assume_role_policy = data.aws_iam_policy_document.trust_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each   = toset(["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore", "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"])
+  role       = aws_iam_role.iam_instance_role.name
+  policy_arn = each.key
+}
+
+data "aws_iam_policy_document" "kms_key_policy_iam_profile" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt"
+
+    ]
+    resources = [aws_kms_key.this.arn]
+  }
+
+}
+
+resource "aws_iam_role_policy" "kms" {
+  role   = aws_iam_role.iam_instance_role.name
+  name   = "inline-policy-kms-access"
+  policy = data.aws_iam_policy_document.kms_key_policy_iam_profile.json
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = local.name
+  role = aws_iam_role.iam_instance_role.name
+}

--- a/modules/bastion/kms.tf
+++ b/modules/bastion/kms.tf
@@ -1,0 +1,48 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+resource "aws_kms_key" "this" {
+  description             = "KMS Key for cloudwatch SSM logging"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.kms_key_policy.json
+}
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "logs.${data.aws_region.current.name}.amazonaws.com"
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+  }
+
+}

--- a/modules/bastion/security_groups.tf
+++ b/modules/bastion/security_groups.tf
@@ -1,0 +1,25 @@
+resource "aws_security_group" "bastion" {
+  name        = var.prefix
+  description = "Allow SSH into bastion"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/modules/bastion/ssm.tf
+++ b/modules/bastion/ssm.tf
@@ -1,0 +1,22 @@
+
+locals {
+  name               = "${var.name}-${random_string.this.result}"
+  cloudwatch_prepend = "/aws/ec2/"
+  # We use basename of the id to ensure dependency-order
+  cloudwatch_loggroup_name = "${local.cloudwatch_prepend}${basename(aws_cloudwatch_log_group.ssm_log.id)}"
+
+}
+
+# Creating a random string for name interpolation
+resource "random_string" "this" {
+  length  = 5
+  special = false
+}
+
+
+resource "aws_cloudwatch_log_group" "ssm_log" {
+  name              = "${local.cloudwatch_prepend}${local.name}"
+  retention_in_days = var.log_retention
+  kms_key_id        = aws_kms_key.this.arn
+
+}

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,0 +1,34 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "vpc_cidr_block" {
+  type = string
+}
+
+variable "private_subnets" {
+  type = list(string)
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "prefix" {
+  type = string
+}
+
+# variable "bastion_allowed_ingress_ip" {
+#   type = string
+# }
+variable "name" {
+  type        = string
+  description = "The name to be interpolated, defaults to bastion-ssm-iam"
+  default     = "bastion-ssm-iam"
+}
+
+variable "log_retention" {
+  type        = number
+  description = "The amount of days the logs need to be kept"
+  default     = 30
+}

--- a/modules/servers_vpc/outputs.tf
+++ b/modules/servers_vpc/outputs.tf
@@ -17,3 +17,8 @@ output "private_route_table_ids" {
 output "public_route_table_ids" {
   value = module.vpc.public_route_table_ids
 }
+
+output "vpc" {
+  value = module.vpc
+
+}

--- a/scripts/aws_ssm_get_parameters.sh
+++ b/scripts/aws_ssm_get_parameters.sh
@@ -6,6 +6,7 @@ export PARAM=$(aws ssm get-parameters --region eu-west-2 --with-decryption --nam
     "/codebuild/dhcp/$ENV/db/username" \
     "/codebuild/dhcp/$ENV/db/password" \
     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/azure_federation_metadata_url" \
+    "/staff-device/dns-dhcp/$ENV/enable_bastion_jumpbox" \
     --query Parameters)
 
 export PARAM2=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
@@ -54,6 +55,7 @@ params["pdns_ips"]="$(echo $PARAM | jq '.[] | select(.Name | test("dns/pdns/ips"
 params["azure_federation_metadata_url"]="$(echo $PARAM | jq '.[] | select(.Name | test("azure_federation_metadata_url")) | .Value' --raw-output)"
 params["dhcp_db_username"]="$(echo $PARAM | jq '.[] | select(.Name | test("db/username")) | .Value' --raw-output)"
 params["dhcp_db_password"]="$(echo $PARAM | jq '.[] | select(.Name | test("db/password")) | .Value' --raw-output)"
+params["enable_bastion_jumpbox"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_bastion_jumpbox")) | .Value' --raw-output)"
 
 params["admin_db_username"]="$(echo $PARAM2 | jq '.[] | select(.Name | test("admin/db/username")) | .Value' --raw-output)"
 params["admin_db_password"]="$(echo $PARAM2 | jq '.[] | select(.Name | test("admin/db/password")) | .Value' --raw-output)"

--- a/variables.tf
+++ b/variables.tf
@@ -187,3 +187,7 @@ variable "owner_email" {
   type    = string
   default = "lanwifi-devops@digital.justice.gov.uk"
 }
+variable "enable_bastion_jumpbox" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
We needed an EC2 instance to perform load testing. Upon investigation, the corsham_test_bastion module already in place did not have AWS SSM (session manager) enabled. The benefit to SSM is it makes the EC2 instance more secure, as it does not require a public IP and exposed SSH ports.
We did bring in a bastion module from staff-infrastructure-network-services, We then tried to depricate the corsham module in favour of the new module, however we found the corsham module has unquie use case. Rather than investigating the corsham module we opted to leave it as it is, and add our new module to enable our load testing. A ticket will be created to investigate, the corsham module and make a updates / refactoring if required.