### PR TITLE
New VPC Endpoints to enable SSM connection to the jumpbox

### DIFF
--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -5,8 +5,8 @@ resource "aws_vpc_endpoint" "ecr_api" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 resource "aws_vpc_endpoint" "ecr_dkr" {
@@ -16,8 +16,8 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 resource "aws_vpc_endpoint" "cloudwatch_logs" {
@@ -27,8 +27,8 @@ resource "aws_vpc_endpoint" "cloudwatch_logs" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 resource "aws_vpc_endpoint" "rds" {
@@ -38,8 +38,8 @@ resource "aws_vpc_endpoint" "rds" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 resource "aws_vpc_endpoint" "monitoring" {
@@ -49,8 +49,8 @@ resource "aws_vpc_endpoint" "monitoring" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 
@@ -58,7 +58,7 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id          = module.vpc.vpc_id
   route_table_ids = module.vpc.private_route_table_ids
   service_name    = "com.amazonaws.${var.region}.s3"
-  tags = var.tags
+  tags            = var.tags
 }
 
 // endpoints required for session manager
@@ -70,8 +70,8 @@ resource "aws_vpc_endpoint" "ssm" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
@@ -81,8 +81,8 @@ resource "aws_vpc_endpoint" "ssmmessages" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
@@ -92,8 +92,8 @@ resource "aws_vpc_endpoint" "ec2messages" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }
 
 resource "aws_vpc_endpoint" "kms" {
@@ -103,6 +103,6 @@ resource "aws_vpc_endpoint" "kms" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-  tags = var.tags
-  depends_on = [aws_security_group.endpoints]
+  tags                = var.tags
+  depends_on          = [aws_security_group.endpoints]
 }

--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -5,9 +5,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-
   tags = var.tags
-
   depends_on = [aws_security_group.endpoints]
 }
 
@@ -18,9 +16,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-
   tags = var.tags
-
   depends_on = [aws_security_group.endpoints]
 }
 
@@ -31,9 +27,7 @@ resource "aws_vpc_endpoint" "cloudwatch_logs" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-
   tags = var.tags
-
   depends_on = [aws_security_group.endpoints]
 }
 
@@ -44,9 +38,7 @@ resource "aws_vpc_endpoint" "rds" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-
   tags = var.tags
-
   depends_on = [aws_security_group.endpoints]
 }
 
@@ -57,9 +49,7 @@ resource "aws_vpc_endpoint" "monitoring" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.endpoints.id]
   private_dns_enabled = true
-
   tags = var.tags
-
   depends_on = [aws_security_group.endpoints]
 }
 
@@ -68,6 +58,51 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id          = module.vpc.vpc_id
   route_table_ids = module.vpc.private_route_table_ids
   service_name    = "com.amazonaws.${var.region}.s3"
-
   tags = var.tags
+}
+
+// endpoints required for session manager
+
+resource "aws_vpc_endpoint" "ssm" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.ssm"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags = var.tags
+  depends_on = [aws_security_group.endpoints]
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags = var.tags
+  depends_on = [aws_security_group.endpoints]
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.ec2messages"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags = var.tags
+  depends_on = [aws_security_group.endpoints]
+}
+
+resource "aws_vpc_endpoint" "kms" {
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.private_subnets
+  service_name        = "com.amazonaws.${var.region}.kms"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+  tags = var.tags
+  depends_on = [aws_security_group.endpoints]
 }


### PR DESCRIPTION
Previously the EC2 instance had no route to AWS SSM, this mean we where unable to connect using console access.

To resolved this we added 4 VPC endpoints required for the session manager to work in dns dhcp vpc

Now, we are able to connect via SSM