### PR TITLE
updated the bastian module to get the AMI by name owned by shared ser…

### DIFF
--- a/modules/bastion/bastion.tf
+++ b/modules/bastion/bastion.tf
@@ -34,7 +34,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+    values = ["nvvs-devops/loadtesting/ubuntu-jammy-22.04-amd64-server-1.0.0"]
   }
 
   filter {
@@ -42,5 +42,10 @@ data "aws_ami" "ubuntu" {
     values = ["hvm"]
   }
 
-  owners = ["099720109477"] # Canonical
+  #   filter {
+  #   name = "tag:env_${terraform.workspace}"
+  #   values = ["true"]
+  # }
+
+  owners = ["683290208331"] # shared services accunt
 }


### PR DESCRIPTION
…vices account,we have created an AMI with preloaded tools for DNS loadtesting in shared services account and shared with prod,pre-prod and development environment. We have done this because  private subnets(where the bastian deployed)  in DNS VPC does not have access to the internet.