### PR TITLE
Added conditional SSM vpc endpoints

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,7 +42,7 @@ env:
     TF_VAR_dhcp_egress_transit_gateway_routes: "/staff-device/$ENV/dhcp_egress_transit_gateway_routes"
     TF_VAR_byoip_pool_id: "/staff-device/dns/$ENV/public_ip_pool_id"
     TF_VAR_enable_corsham_test_bastion: "/staff-device/dns-dhcp/$ENV/enable_bastion"
-    TF_VAR_enable_bastion_jumpbox: "/staff-device/dns-dhcp/$ENV/enable_bastion_jumpbox"
+    TF_VAR_enable_load_testing: "/staff-device/dns-dhcp/$ENV/enable_load_testing"
     TF_VAR_allowed_ip_ranges: "/staff-device/dns-dhcp/admin/$ENV/allowed_ip_ranges"
     ROLE_ARN: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/assume_role"
     TF_VAR_api_basic_auth_username: "/codebuild/dhcp/admin/api/basic_auth_username"

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ module "servers_vpc" {
   region                                 = data.aws_region.current_region.id
   tags                                   = module.dhcp_label.tags
   transit_gateway_route_table_id         = var.transit_gateway_route_table_id
+  ssm_session_manager_endpoints          = var.enable_load_testing
 
   providers = {
     aws = aws.env
@@ -262,20 +263,20 @@ module "dns" {
   }
 }
 
-module "bastion_label" {
+module "load_testing_label" {
   source       = "./modules/label"
   service_name = "dns-bastion"
   owner_email  = var.owner_email
 }
 
-module "bastion" {
+module "load_testing" {
   source          = "./modules/bastion"
-  prefix          = module.bastion_label.id
+  prefix          = module.load_testing_label.id
   vpc_id          = module.servers_vpc.vpc.vpc_id
   vpc_cidr_block  = module.servers_vpc.vpc.vpc_cidr_block
   private_subnets = module.servers_vpc.vpc.private_subnets
   //bastion_allowed_ingress_ip = var.bastion_allowed_ingress_ip
-  tags = module.bastion_label.tags
+  tags = module.load_testing_label.tags
 
   providers = {
     aws = aws.env
@@ -283,7 +284,7 @@ module "bastion" {
 
   depends_on = [module.servers_vpc]
 
-  count = var.enable_bastion_jumpbox == true ? 1 : 0
+  count = var.enable_load_testing == true ? 1 : 0
 }
 
 module "corsham_test_bastion" {

--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -64,7 +64,7 @@ resource "aws_vpc_endpoint" "s3" {
 // endpoints required for session manager
 
 resource "aws_vpc_endpoint" "ssm" {
-  count = var.ssm_session_manager_endpoints ? 1 : 0
+  count               = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.ssm"
@@ -76,7 +76,7 @@ resource "aws_vpc_endpoint" "ssm" {
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
-  count = var.ssm_session_manager_endpoints ? 1 : 0
+  count               = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.ssmmessages"
@@ -88,7 +88,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
-  count = var.ssm_session_manager_endpoints ? 1 : 0
+  count               = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.ec2messages"
@@ -100,7 +100,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
 }
 
 resource "aws_vpc_endpoint" "kms" {
-  count = var.ssm_session_manager_endpoints ? 1 : 0
+  count               = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.kms"

--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -64,6 +64,7 @@ resource "aws_vpc_endpoint" "s3" {
 // endpoints required for session manager
 
 resource "aws_vpc_endpoint" "ssm" {
+  count = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.ssm"
@@ -75,6 +76,7 @@ resource "aws_vpc_endpoint" "ssm" {
 }
 
 resource "aws_vpc_endpoint" "ssmmessages" {
+  count = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.ssmmessages"
@@ -86,6 +88,7 @@ resource "aws_vpc_endpoint" "ssmmessages" {
 }
 
 resource "aws_vpc_endpoint" "ec2messages" {
+  count = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.ec2messages"
@@ -97,6 +100,7 @@ resource "aws_vpc_endpoint" "ec2messages" {
 }
 
 resource "aws_vpc_endpoint" "kms" {
+  count = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.private_subnets
   service_name        = "com.amazonaws.${var.region}.kms"

--- a/modules/servers_vpc/variables.tf
+++ b/modules/servers_vpc/variables.tf
@@ -48,6 +48,6 @@ variable "model_office_vm_ip" {
 }
 
 variable "ssm_session_manager_endpoints" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/modules/servers_vpc/variables.tf
+++ b/modules/servers_vpc/variables.tf
@@ -46,3 +46,8 @@ variable "corsham_vm_ip" {
 variable "model_office_vm_ip" {
   type = string
 }
+
+variable "ssm_session_manager_endpoints" {
+  type = bool
+  default = false
+}

--- a/scripts/aws_ssm_get_parameters.sh
+++ b/scripts/aws_ssm_get_parameters.sh
@@ -6,7 +6,7 @@ export PARAM=$(aws ssm get-parameters --region eu-west-2 --with-decryption --nam
     "/codebuild/dhcp/$ENV/db/username" \
     "/codebuild/dhcp/$ENV/db/password" \
     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/azure_federation_metadata_url" \
-    "/staff-device/dns-dhcp/$ENV/enable_bastion_jumpbox" \
+    "/staff-device/dns-dhcp/$ENV/enable_load_testing" \
     --query Parameters)
 
 export PARAM2=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
@@ -55,7 +55,7 @@ params["pdns_ips"]="$(echo $PARAM | jq '.[] | select(.Name | test("dns/pdns/ips"
 params["azure_federation_metadata_url"]="$(echo $PARAM | jq '.[] | select(.Name | test("azure_federation_metadata_url")) | .Value' --raw-output)"
 params["dhcp_db_username"]="$(echo $PARAM | jq '.[] | select(.Name | test("db/username")) | .Value' --raw-output)"
 params["dhcp_db_password"]="$(echo $PARAM | jq '.[] | select(.Name | test("db/password")) | .Value' --raw-output)"
-params["enable_bastion_jumpbox"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_bastion_jumpbox")) | .Value' --raw-output)"
+params["enable_load_testing"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_load_testing")) | .Value' --raw-output)"
 
 params["admin_db_username"]="$(echo $PARAM2 | jq '.[] | select(.Name | test("admin/db/username")) | .Value' --raw-output)"
 params["admin_db_password"]="$(echo $PARAM2 | jq '.[] | select(.Name | test("admin/db/password")) | .Value' --raw-output)"

--- a/variables.tf
+++ b/variables.tf
@@ -187,7 +187,7 @@ variable "owner_email" {
   type    = string
   default = "lanwifi-devops@digital.justice.gov.uk"
 }
-variable "enable_bastion_jumpbox" {
+variable "enable_load_testing" {
   type    = bool
   default = false
 }


### PR DESCRIPTION
We currently have a switch to be able to turn on or off the load testing EC2. We decide it was inefficient to have VPC endpoints being deployed and not being used when the load testing bastion is off. Thus we have added a condition for this. We have also refactored the naming of the module to be more reflective of the load testing use case.


