### PR TITLE
Fix connection and public IP issues and add documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This repository defines the **system infrastructure only**. Specific components 
 - [Networking](documentation/networking.md)
 - [Disaster Recovery](documentation/disaster-recovery.md)
 - [Incident Reports](documentation/incident-reports.md)
+- [Database Access - dump with bastion](documentation/rds-bastion.md)
 
 ## Architecture
 

--- a/bastion-rds-admin.tf
+++ b/bastion-rds-admin.tf
@@ -10,18 +10,18 @@ module "rds_admin_bastion" {
   vpc_id                      = module.admin_vpc.vpc.vpc_id
   vpc_cidr_block              = module.admin_vpc.vpc.vpc_cidr_block
   private_subnets             = module.admin_vpc.public_subnets
-  security_group_ids          = [module.admin.security_group_ids.admin_ecs]
+  security_group_ids          = [module.admin.security_group_ids.admin_ecs, module.admin_vpc.endpoints_sg.id]
   ami_name                    = "diso-devops/bastion/rds-admin/ubuntu-jammy-22.04-amd64-server-1.0.1"
   number_of_bastions          = 1
   assume_role                 = local.s3-mojo_file_transfer_assume_role_arn
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   tags                        = module.rds_admin_bastion_label.tags
 
   providers = {
     aws = aws.env
   }
 
-  depends_on = [module.servers_vpc]
+  depends_on = [module.admin_vpc]
   // Set in SSM parameter store, true or false to enable or disable this module.
   count = var.enable_rds_admin_bastion == true ? 1 : 0
 }

--- a/bastion-rds-servers.tf
+++ b/bastion-rds-servers.tf
@@ -10,11 +10,11 @@ module "rds_servers_bastion" {
   vpc_id                      = module.servers_vpc.vpc.vpc_id
   vpc_cidr_block              = module.servers_vpc.vpc.vpc_cidr_block
   private_subnets             = module.servers_vpc.public_subnets
-  security_group_ids          = [module.dhcp.security_group_ids.dhcp_server]
+  security_group_ids          = [module.dhcp.security_group_ids.dhcp_server, module.servers_vpc.endpoints_sg.id]
   ami_name                    = "diso-devops/bastion/rds-admin/ubuntu-jammy-22.04-amd64-server-1.0.1"
   number_of_bastions          = 1
   assume_role                 = local.s3-mojo_file_transfer_assume_role_arn
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   tags                        = module.rds_servers_bastion_label.tags
 
   providers = {

--- a/documentation/rds-bastion.md
+++ b/documentation/rds-bastion.md
@@ -1,0 +1,201 @@
+# RDS Bastion
+
+In order to carry out various maintenance tasks such as obtaining a database dump for loading into a local development DB; or obtain data that currently isn't available via an export mechanism; a bastion is created.
+
+The bastion doesn't have any service exposed to the public like a "jump box" bastion e.g. SSH on port 22 as it is only accessible via the AWS Session Manager.
+
+The routine is
+
+- Enable
+  - Enable the bastion via an "enable" flag set in AWS SSM Parameter Store to `true`.
+  - Deploy by running the CI pipeline.
+  - Create an SSM Session.
+  - Carry out required procedure
+
+- Configure
+  - Simple set up to enable assuming a role
+
+- Removal
+  - Disallow the bastion via an "enable" flag set in AWS SSM Parameter Store to `false`.
+  - Omit by running the CI pipeline.
+
+
+## Enable
+
+### Spin up a bastion
+
+Set the boolean value in parameter store to `true`
+run the pipeline
+
+### Get environment details for the target env
+
+```
+make gen-env ENV_ARGUMENT=production
+```
+
+### run the script to identify the bastion instance id
+
+```
+make aws_describe_instances
+```
+
+Then identify the running bastion host
+```
+i-019174128cf7b4563|  t3a.small  |  None           |  running |  mojo-production-rds-admin-bastion
+```
+
+### Start session on bastion
+
+Run make command with instance id
+
+```
+make aws_ssm_start_session INSTANCE_ID=i-019174128cf7b4563
+```
+
+## Configure
+
+First we need to enable an AWS role to transfer files to (or from) an S3 transfer bucket.
+
+```
+#######################
+## Create AWS config ##
+#######################
+
+
+mkdir ~/.aws; \
+cat << 'EOF' > ~/.aws/config
+[profile s3-role]
+role_arn = arn:aws:iam::683290208331:role/s3-mojo-file-transfer-assume-role
+credential_source = Ec2InstanceMetadata
+EOF
+```
+
+now test with the following aws cli command
+
+```
+aws sts get-caller-identity
+```
+
+then access to the s3 bucket
+
+```
+aws s3 ls s3://mojo-file-transfer/ --profile s3-role;
+````
+
+## Get a DB dump
+
+from another terminal window in the root of the project run
+
+```shell
+make shell
+```
+
+the issue a terraform command to get the database details
+
+Admin (dhcp & dns)
+```shell
+terraform output -json terraform_outputs | jq '.admin.db'
+```
+
+DHCP
+```shell
+terraform output -json terraform_outputs | jq '.dhcp.db'
+```
+
+Admin (NAC)* note: NAC code used `rds` as module name.
+```shell
+terraform output -json terraform_outputs | jq '.admin.rds'
+```
+
+To get the password run
+
+```shell
+./scripts/get_db_parameters.sh
+```
+
+##   DHCP Database Backup and Restore
+
+In order to connect to the database the following items will be needed.
+
+- fqdn e.g. `"fqdn": "dhcp-dns-admin-dhcp-db.dev.staff.service.justice.gov.uk",`
+- username e.g. `"username": "adminuser"`
+- password
+
+### Test connection
+
+```shell
+fqdn=dhcp-dns-admin-db.dev.staff.service.justice.gov.uk && curl -v telnet://${fqdn}:3306 --output rds.txt
+```
+
+### Connect to DB
+
+```shell
+fqdn=dhcp-dns-admin-db.dev.staff.service.justice.gov.uk
+admin_db_username=adminuser
+mysql -u ${admin_db_username} -p -h ${fqdn}
+
+## enter password when prompted
+Enter password:
+```
+
+You should see the MySQL command prompt.
+
+```shell
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 80936
+Server version: 5.7.42-log Source distribution
+
+Copyright (c) 2000, 2023, Oracle and/or its affiliates.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql>
+```
+
+Run some SQL queries to identify the database name etc.
+
+### which databases?
+
+```sql
+mysql>
+show databases;
+```
+
+### Use the database and see the table names
+
+```sql
+mysql> 
+use staffdevicedevelopmentdhcpadmin;
+show tables;
+```
+
+### Get a DB dump
+
+Create a timestamped database dump and upload it to S3 transfer bucket (copy and paste as below, update variable values as required.)
+
+```shell
+env="DEVELOPMENT"; \
+db_name="staffdevicedevelopmentdhcpadmin"; \
+filename="`date "+%Y_%m_%d-%H_%M_%S"`_${env}_${db_name}_rds-dump.sql"; \
+fqdn="dhcp-dns-admin-db.dev.staff.service.justice.gov.uk"; \
+admin_db_username="adminuser"; \
+mysqldump \
+	-u "${admin_db_username}" \
+	-p \
+	--set-gtid-purged=OFF \
+	--triggers --routines --events \
+	-h "${fqdn}"  \
+	"${db_name}" > ~/${filename}; \
+	ls -al; \
+aws s3 cp ~/${filename} s3://mojo-file-transfer/ --profile s3-role; \
+aws s3 ls s3://mojo-file-transfer/ --profile s3-role;
+```
+
+## Removal
+
+Set the boolean value in parameter store to `false`
+run the pipeline

--- a/documentation/rds-bastion.md
+++ b/documentation/rds-bastion.md
@@ -7,18 +7,19 @@ The bastion doesn't have any service exposed to the public like a "jump box" bas
 The routine is
 
 - Enable
+
   - Enable the bastion via an "enable" flag set in AWS SSM Parameter Store to `true`.
   - Deploy by running the CI pipeline.
   - Create an SSM Session.
   - Carry out required procedure
 
 - Configure
+
   - Simple set up to enable assuming a role
 
 - Removal
   - Disallow the bastion via an "enable" flag set in AWS SSM Parameter Store to `false`.
   - Omit by running the CI pipeline.
-
 
 ## Enable
 
@@ -40,6 +41,7 @@ make aws_describe_instances
 ```
 
 Then identify the running bastion host
+
 ```
 i-019174128cf7b4563|  t3a.small  |  None           |  running |  mojo-production-rds-admin-bastion
 ```
@@ -80,7 +82,7 @@ then access to the s3 bucket
 
 ```
 aws s3 ls s3://mojo-file-transfer/ --profile s3-role;
-````
+```
 
 ## Get a DB dump
 
@@ -93,16 +95,19 @@ make shell
 the issue a terraform command to get the database details
 
 Admin (dhcp & dns)
+
 ```shell
 terraform output -json terraform_outputs | jq '.admin.db'
 ```
 
 DHCP
+
 ```shell
 terraform output -json terraform_outputs | jq '.dhcp.db'
 ```
 
-Admin (NAC)* note: NAC code used `rds` as module name.
+Admin (NAC)\* note: NAC code used `rds` as module name.
+
 ```shell
 terraform output -json terraform_outputs | jq '.admin.rds'
 ```
@@ -113,7 +118,7 @@ To get the password run
 ./scripts/get_db_parameters.sh
 ```
 
-##   DHCP Database Backup and Restore
+## DHCP Database Backup and Restore
 
 In order to connect to the database the following items will be needed.
 
@@ -168,7 +173,7 @@ show databases;
 ### Use the database and see the table names
 
 ```sql
-mysql> 
+mysql>
 use staffdevicedevelopmentdhcpadmin;
 show tables;
 ```

--- a/modules/admin/outputs.tf
+++ b/modules/admin/outputs.tf
@@ -23,3 +23,16 @@ output "security_group_ids" {
     admin_ecs = aws_security_group.admin_ecs.id
   }
 }
+
+output "db" {
+  value = {
+    arn                 = aws_db_instance.admin_db.arn
+    endpoint            = aws_db_instance.admin_db.endpoint
+    fqdn                = aws_route53_record.admin_db.fqdn
+    id                  = aws_db_instance.admin_db.id
+    name                = aws_db_instance.admin_db.db_name
+    port                = aws_db_instance.admin_db.port
+    rds_monitoring_role = aws_iam_role.rds_monitoring_role.arn
+    username            = aws_db_instance.admin_db.username
+  }
+}

--- a/modules/dhcp/outputs.tf
+++ b/modules/dhcp/outputs.tf
@@ -82,10 +82,13 @@ output "db_port" {
 output "db" {
   value = {
     address  = aws_db_instance.dhcp_server_db.address
-    name     = aws_db_instance.dhcp_server_db.db_name
-    fqdn     = aws_route53_record.dhcp_db.fqdn
-    port     = aws_db_instance.dhcp_server_db.port
+    arn      = aws_db_instance.dhcp_server_db.arn
     endpoint = aws_db_instance.dhcp_server_db.endpoint
+    fqdn     = aws_route53_record.dhcp_db.fqdn
+    id       = aws_db_instance.dhcp_server_db.id
+    name     = aws_db_instance.dhcp_server_db.db_name
+    port     = aws_db_instance.dhcp_server_db.port
+    username = aws_db_instance.dhcp_server_db.username
   }
 }
 

--- a/modules/servers_vpc/outputs.tf
+++ b/modules/servers_vpc/outputs.tf
@@ -21,3 +21,23 @@ output "public_route_table_ids" {
 output "vpc" {
   value = module.vpc
 }
+
+output "vpc_brief" {
+  value = {
+    azs                         = module.vpc.azs
+    id                          = module.vpc.vpc_id
+    name                        = module.vpc.name
+    private_route_table_ids     = module.vpc.private_route_table_ids
+    private_subnets             = module.vpc.private_subnets
+    private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    public_route_table_ids      = module.vpc.public_route_table_ids
+    public_subnets              = module.vpc.public_subnets
+    public_subnets_cidr_blocks  = module.vpc.public_subnets_cidr_blocks
+  }
+}
+
+output "endpoints_sg" {
+  value = {
+    id = aws_security_group.endpoints.id
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -17,3 +17,23 @@ output "public_route_table_ids" {
 output "vpc" {
   value = module.vpc
 }
+
+output "vpc_brief" {
+  value = {
+    azs                         = module.vpc.azs
+    id                          = module.vpc.vpc_id
+    name                        = module.vpc.name
+    private_route_table_ids     = module.vpc.private_route_table_ids
+    private_subnets             = module.vpc.private_subnets
+    private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+    public_route_table_ids      = module.vpc.public_route_table_ids
+    public_subnets              = module.vpc.public_subnets
+    public_subnets_cidr_blocks  = module.vpc.public_subnets_cidr_blocks
+  }
+}
+
+output "endpoints_sg" {
+  value = {
+    id = aws_security_group.endpoints.id
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,9 +19,15 @@ output "terraform_outputs" {
       ecr = module.dns.ecr
     }
 
+    servers = {
+      vpc = module.servers_vpc.vpc_brief
+    }
+
     admin = {
       ecs = module.admin.ecs
       ecr = module.admin.ecr
+      db  = module.admin.db
+      vpc = module.admin_vpc.vpc_brief
     }
 
     metrics_namespace = var.metrics_namespace

--- a/scripts/aws_ssm_set_parameters.sh
+++ b/scripts/aws_ssm_set_parameters.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+ENV="${1:-development}"
+ENABLE_RDS_SERVERS_BASTION="${2:-false}"
+ENABLE_RDS_ADMIN_BASTION="${3:-false}"
+ENABLE_LOAD_TESTING="${4:-false}"
+
+echo $ENV
+
+
+### rds_servers_bastion
+#aws ssm put-parameter \
+#    --name "/staff-device/dns-dhcp/development/enable_rds_servers_bastion" \
+#    --type "String" \
+#    --value "$ENABLE_RDS_SERVERS_BASTION" \
+#    --overwrite
+#
+### rds_admin_bastion
+#aws ssm put-parameter \
+#    --name "/staff-device/dns-dhcp/development/enable_rds_admin_bastion" \
+#    --type "String" \
+#    --value "$ENABLE_RDS_ADMIN_BASTION" \
+#    --overwrite
+#
+#
+### enable_load_testing
+#aws ssm put-parameter \
+#    --name "/staff-device/dns-dhcp/development/enable_load_testing" \
+#    --type "String" \
+#    --value "$ENABLE_LOAD_TESTING" \
+#    --overwrite
+
+
+export PARAM=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
+    "/staff-device/dns-dhcp/$ENV/enable_load_testing" \
+    "/staff-device/dns-dhcp/$ENV/number_of_load_testing_nodes" \
+    "/staff-device/dns-dhcp/$ENV/enable_rds_admin_bastion" \
+    "/staff-device/dns-dhcp/$ENV/enable_rds_servers_bastion" \
+    "/staff-device/dns-dhcp/$ENV/enable_bastion" \
+    --query Parameters)
+
+declare -A params
+
+params["enable_load_testing"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_load_testing")) | .Value' --raw-output)"
+params["number_of_load_testing_nodes"]="$(echo $PARAM | jq '.[] | select(.Name | test("number_of_load_testing_nodes")) | .Value' --raw-output)"
+params["enable_rds_admin_bastion"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_rds_admin_bastion")) | .Value' --raw-output)"
+params["enable_rds_servers_bastion"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_rds_servers_bastion")) | .Value' --raw-output)"
+params["enable_corsham_test_bastion"]="$(echo $PARAM | jq '.[] | select(.Name | test("enable_bastion")) | .Value' --raw-output)"
+
+for key in "${!params[@]}"
+do
+  echo "${key}=${params[${key}]}"
+done

--- a/scripts/get_db_parameters.sh
+++ b/scripts/get_db_parameters.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+export PARAM=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
+    "/codebuild/dhcp/$ENV/admin/db/username" \
+    "/codebuild/dhcp/$ENV/admin/db/password" \
+    --query Parameters)
+
+export PARAM1=$(aws ssm get-parameters --region eu-west-2 --with-decryption --names \
+    "/codebuild/dhcp/$ENV/db/username" \
+    "/codebuild/dhcp/$ENV/db/password" \
+    --query Parameters)
+
+echo
+echo $ENV
+echo
+#echo $PARAM
+#echo $PARAM1
+
+declare -A params
+
+params["admin_db_password"]="$(echo $PARAM | jq '.[] | select(.Name | test("admin/db/password")) | .Value' --raw-output)"
+params["admin_db_username"]="$(echo $PARAM | jq '.[] | select(.Name | test("admin/db/username")) | .Value' --raw-output)"
+params["dhcp_db_password"]="$(echo $PARAM1 | jq '.[] | select(.Name | test("db/password")) | .Value' --raw-output)"
+params["dhcp_db_username"]="$(echo $PARAM1 | jq '.[] | select(.Name | test("db/username")) | .Value' --raw-output)"
+
+
+
+for key in "${!params[@]}"
+do
+  echo "${key}=${params[${key}]}"
+done

--- a/vpc_servers.tf
+++ b/vpc_servers.tf
@@ -13,7 +13,7 @@ module "servers_vpc" {
   region                                 = data.aws_region.current_region.id
   tags                                   = module.dhcp_label.tags
   transit_gateway_route_table_id         = var.transit_gateway_route_table_id
-  ssm_session_manager_endpoints          = var.enable_load_testing
+  ssm_session_manager_endpoints          = var.enable_load_testing || var.enable_rds_servers_bastion ? true : false
 
   providers = {
     aws = aws.env


### PR DESCRIPTION
During the development of the NACs RDS Bastion feature, it was noted that this implementation had some issues.

associate_public_ip_address | this was incorrectly set.
security_group_ids | the VPC endpoinst security group had been omitted.
ssm_session_manager_endpoints | for the services required some logic as they are shared with the load testing bastion.
In order to create an easy engineer experience some additional outputs have been added for consistency across the two projects.

The documentation has been added.