### PR TITLE
Parameter tier for terraform outputs too small

### DIFF
--- a/scripts/publish_terraform_outputs.sh
+++ b/scripts/publish_terraform_outputs.sh
@@ -10,6 +10,7 @@ aws ssm put-parameter --name "/terraform_dns_dhcp/$ENV/outputs" \
   --description "Terraform outputs that other pipelines or processes depend on" \
   --value "$terraform_outputs" \
   --type String \
+  --tier Intelligent-Tiering \
   --overwrite
 
 dns_dhcp_vpc_id=$(terraform output --raw dns_dhcp_vpc_id)


### PR DESCRIPTION
During the publish terraform outputs operation the script failed becasuse the data has exceeded the standard tier of 4KB. Specifying "Intelligent-Tiering" for this parameter so that it will default to "Advanced" 8KB when necessary.