### PR TITLE
Feature/nd174 secrets accessible in plain text

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,6 @@ env:
   variables:
     #TF_IN_AUTOMATION: true
     TF_INPUT: 0
-    TF_VAR_env: development
     TF_VAR_enable_critical_notifications: true
     TF_VAR_enable_authentication: true
     TF_VAR_admin_db_backup_retention_period: 30
@@ -61,6 +60,7 @@ phases:
 
   build:
     commands:
+      - export TF_VAR_env=${ENV} 
       - export AWS_DEFAULT_REGION=eu-west-2
       - terraform init -no-color --backend-config="key=terraform.$ENV.state"
       - terraform workspace new $ENV || true

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -60,7 +60,7 @@ phases:
 
   build:
     commands:
-      - export TF_VAR_env=${ENV} 
+      - export TF_VAR_env=${ENV}
       - export AWS_DEFAULT_REGION=eu-west-2
       - terraform init -no-color --backend-config="key=terraform.$ENV.state"
       - terraform workspace new $ENV || true

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ env:
   variables:
     #TF_IN_AUTOMATION: true
     TF_INPUT: 0
-    TF_VAR_env: ${ENV}
+    TF_VAR_env: development
     TF_VAR_enable_critical_notifications: true
     TF_VAR_enable_authentication: true
     TF_VAR_admin_db_backup_retention_period: 30

--- a/modules/admin/cluster.tf
+++ b/modules/admin/cluster.tf
@@ -8,8 +8,8 @@ terraform {
 }
 
 locals {
-  memory     = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
-  cpu        = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
+  memory = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
+  cpu    = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
 }
 
 resource "aws_ecs_cluster" "admin_cluster" {

--- a/modules/admin/iam.tf
+++ b/modules/admin/iam.tf
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_policy_attachment" {
   for_each = toset([
-    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy", 
+    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
     "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
   ])
 

--- a/modules/dhcp/ecs_task_definition.tf
+++ b/modules/dhcp/ecs_task_definition.tf
@@ -1,8 +1,8 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  memory     = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
-  cpu        = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
+  memory = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
+  cpu    = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
 }
 
 resource "aws_ecs_task_definition" "server_task" {

--- a/modules/dhcp_standby/ecs_task_definition.tf
+++ b/modules/dhcp_standby/ecs_task_definition.tf
@@ -1,8 +1,8 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  memory     = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
-  cpu        = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
+  memory = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "4096" : "1024"
+  cpu    = terraform.workspace == "production" || terraform.workspace == "pre-production" ? "2048" : "512"
 }
 
 resource "aws_ecs_task_definition" "server_task" {

--- a/modules/dns_dhcp_common/iam.tf
+++ b/modules/dns_dhcp_common/iam.tf
@@ -85,7 +85,7 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_policy_attachment" {
   for_each = toset([
-    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy", 
+    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
     "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
   ])
 


### PR DESCRIPTION
added new export parameter for env variables because original approach is not working as takes the literal value e.g. ENV and does not output the value of environment (e.g. development)