### PR TITLE
Revert "Feature/nd174 secrets accessible in plain text"

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,6 +4,7 @@ env:
   variables:
     #TF_IN_AUTOMATION: true
     TF_INPUT: 0
+    TF_VAR_env: ${ENV}
     TF_VAR_enable_critical_notifications: true
     TF_VAR_enable_authentication: true
     TF_VAR_admin_db_backup_retention_period: 30
@@ -60,7 +61,6 @@ phases:
 
   build:
     commands:
-      - export TF_VAR_env=${ENV}
       - export AWS_DEFAULT_REGION=eu-west-2
       - terraform init -no-color --backend-config="key=terraform.$ENV.state"
       - terraform workspace new $ENV || true


### PR DESCRIPTION
Reverts ministryofjustice/staff-device-dns-dhcp-infrastructure#322

Having issues with deployment to preprod, seeing the following error which was not seen in dev deployment which ran smoothly:

Stopped reason
ResourceInitializationError: unable to pull secrets or registry auth: execution resource retrieval failed: unable to retrieve secrets from ssm: service call has been retried 5 time(s): RequestCanceled: request context canceled caused by: context deadline exceeded. Please check your task network configuration.