### PR TITLE
Revert "configured vpc endpoint to be always on, previously depended on bastions being enabled"

### DIFF
--- a/modules/vpc/endpoints.tf
+++ b/modules/vpc/endpoints.tf
@@ -27,9 +27,10 @@ resource "aws_vpc_endpoint" "s3" {
   tags            = var.tags
 }
 
-// enpoint required for bastions and ecs task get ssm parameters
+// endpoints required for session manager
 
 resource "aws_vpc_endpoint" "ssm" {
+  count               = var.ssm_session_manager_endpoints ? 1 : 0
   vpc_id              = module.vpc.vpc_id
   subnet_ids          = module.vpc.public_subnets
   service_name        = "com.amazonaws.${var.region}.ssm"
@@ -39,8 +40,6 @@ resource "aws_vpc_endpoint" "ssm" {
   tags                = var.tags
   depends_on          = [aws_security_group.endpoints]
 }
-
-// endpoints required for bastions session manager 
 
 resource "aws_vpc_endpoint" "ssmmessages" {
   count               = var.ssm_session_manager_endpoints ? 1 : 0


### PR DESCRIPTION
Reverts ministryofjustice/staff-device-dns-dhcp-infrastructure#325

reverting as made the change in the wrong location