### PR TITLE
 changing the maximum task count to 18

### DIFF
--- a/modules/dns/ecs_auto_scaling.tf
+++ b/modules/dns/ecs_auto_scaling.tf
@@ -1,7 +1,7 @@
 resource "aws_appautoscaling_target" "auth_ecs_target" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.server_cluster.name}/${aws_ecs_service.service.name}"
-  max_capacity       = 12
+  max_capacity       = 18
   min_capacity       = terraform.workspace == "production" ? 3 : 2
   scalable_dimension = "ecs:service:DesiredCount"
 }


### PR DESCRIPTION
- Setting maximum task count to 18 to allow more capacity in DNS cluster. This is to address recent scaling events and potential higher demand from DOM1 state.