### PR TITLE
Adding user_data script to RDS bastion

### DIFF
--- a/modules/bastion/bastion.tf
+++ b/modules/bastion/bastion.tf
@@ -7,10 +7,20 @@ terraform {
   }
 }
 
+data "template_file" "user_data" {
+  template = file("${path.module}/user_data/user_data.sh")
+
+  vars = {
+    project_name = var.ami_name
+  }
+}
+
 resource "aws_instance" "bastion" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = "t3a.small"
   count         = var.number_of_bastions
+
+  user_data = data.template_file.user_data.rendered
 
   vpc_security_group_ids = setunion(var.security_group_ids, [aws_security_group.bastion.id])
 

--- a/modules/bastion/user_data/user_data.sh
+++ b/modules/bastion/user_data/user_data.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -x
+
+mkdir ~/.aws
+cat << 'EOF' > ~/.aws/config
+[profile s3-role]
+role_arn = arn:aws:iam::683290208331:role/s3-mojo-file-transfer-assume-role
+credential_source = Ec2InstanceMetadata
+EOF


### PR DESCRIPTION
Initially this is to add the aws "s3-mojo-file-transfer-assume-role" to the instance. This allows access to the s3 file transfer bucket.

ND-510