### PR TITLE
Added route for s3 endpoint

### DIFF
--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -65,10 +65,11 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint" "sts" {
-  vpc_id          = module.vpc.vpc_id
-  route_table_ids = module.vpc.public_route_table_ids
-  service_name    = "com.amazonaws.${var.region}.sts"
-  tags            = var.tags
+  vpc_id            = module.vpc.vpc_id
+  route_table_ids   = module.vpc.public_route_table_ids
+  service_name      = "com.amazonaws.${var.region}.sts"
+  vpc_endpoint_type = "Interface"
+  tags              = var.tags
 }
 
 

--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -56,7 +56,10 @@ resource "aws_vpc_endpoint" "monitoring" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id          = module.vpc.vpc_id
-  route_table_ids = module.vpc.private_route_table_ids
+  route_table_ids = concat(
+    module.vpc.private_route_table_ids,
+    module.vpc.public_route_table_ids
+  )
   service_name    = "com.amazonaws.${var.region}.s3"
   tags            = var.tags
 }

--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -65,11 +65,13 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 resource "aws_vpc_endpoint" "sts" {
-  vpc_id            = module.vpc.vpc_id
-  route_table_ids   = module.vpc.public_route_table_ids
-  service_name      = "com.amazonaws.${var.region}.sts"
-  vpc_endpoint_type = "Interface"
-  tags              = var.tags
+  vpc_id              = module.vpc.vpc_id
+  subnet_ids          = module.vpc.public_subnets
+  service_name        = "com.amazonaws.${var.region}.sts"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = [aws_security_group.endpoints.id]
+  tags                = var.tags
 }
 
 

--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -64,6 +64,13 @@ resource "aws_vpc_endpoint" "s3" {
   tags            = var.tags
 }
 
+resource "aws_vpc_endpoint" "sts" {
+  vpc_id          = module.vpc.vpc_id
+  route_table_ids = module.vpc.public_route_table_ids
+  service_name    = "com.amazonaws.${var.region}.sts"
+  tags            = var.tags
+}
+
 
 // enpoint required for bastions and ecs task get ssm parameters & secrets manager
 

--- a/modules/servers_vpc/endpoints.tf
+++ b/modules/servers_vpc/endpoints.tf
@@ -55,13 +55,13 @@ resource "aws_vpc_endpoint" "monitoring" {
 
 
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id          = module.vpc.vpc_id
+  vpc_id = module.vpc.vpc_id
   route_table_ids = concat(
     module.vpc.private_route_table_ids,
     module.vpc.public_route_table_ids
   )
-  service_name    = "com.amazonaws.${var.region}.s3"
-  tags            = var.tags
+  service_name = "com.amazonaws.${var.region}.s3"
+  tags         = var.tags
 }
 
 resource "aws_vpc_endpoint" "sts" {


### PR DESCRIPTION
added new route so that bastion in public subnet can access the s3 endpoint. (This is needed because the bastion cannot use the internet gateway as it has now assigned ipv4 or ipv6 address)