### PR TITLE
enable ecs sessions manager for dns-dhcp

### DIFF
--- a/modules/dns/ecs.tf
+++ b/modules/dns/ecs.tf
@@ -10,12 +10,12 @@ resource "aws_ecs_cluster" "server_cluster" {
 }
 
 resource "aws_ecs_service" "service" {
-  name            = "${var.prefix}-service"
-  cluster         = aws_ecs_cluster.server_cluster.id
-  task_definition = aws_ecs_task_definition.server_task.arn
-  desired_count   = 5
-  launch_type     = "FARGATE"
-  tags            = var.tags
+  name                   = "${var.prefix}-service"
+  cluster                = aws_ecs_cluster.server_cluster.id
+  task_definition        = aws_ecs_task_definition.server_task.arn
+  desired_count          = 5
+  launch_type            = "FARGATE"
+  tags                   = var.tags
   enable_execute_command = true
 
   lifecycle {

--- a/modules/dns/ecs.tf
+++ b/modules/dns/ecs.tf
@@ -16,6 +16,7 @@ resource "aws_ecs_service" "service" {
   desired_count   = 5
   launch_type     = "FARGATE"
   tags            = var.tags
+  enable_execute_command = true
 
   lifecycle {
     ignore_changes = [desired_count]

--- a/modules/dns_dhcp_common/iam.tf
+++ b/modules/dns_dhcp_common/iam.tf
@@ -77,7 +77,16 @@ resource "aws_iam_role_policy" "ecs_task_policy" {
         "cloudwatch:PutMetricData"
       ],
       "Resource": ["*"]
-    }
+    },{
+      "Effect": "Allow",
+      "Action": [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": ["*"]
+  }
   ]
 }
 EOF


### PR DESCRIPTION
added permissions for AWS Sessions manager to be allowed to connect with ECS DNS tasks