### PR TITLE
slighty up the autoscaling threshold to remoeve containers

### DIFF
--- a/modules/dns/ecs_auto_scaling.tf
+++ b/modules/dns/ecs_auto_scaling.tf
@@ -124,7 +124,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_low" {
   namespace           = "AWS/ECS"
   period              = "60"
   statistic           = "Average"
-  threshold           = "20"
+  threshold           = "25"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.server_cluster.name


### PR DESCRIPTION
Now we have doubled the size of the containers, we have now solved the issue whereby we where running at 100% containers. However given the containers now have double the capacity after reviewing past performance there is room to up the autoscaling threshold to prevent over-provisioning and bring down AWS cost.