### PR TITLE
 lowering period of alerts

### DIFF
--- a/modules/dns/ecs_auto_scaling.tf
+++ b/modules/dns/ecs_auto_scaling.tf
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpu_alarm_low" {
   evaluation_periods  = "1"
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = "60"
+  period              = "300"
   statistic           = "Average"
   threshold           = "25"
 


### PR DESCRIPTION
Currently we are seeing alot of scaling activity. Changing the period from 1 min to 5 mins means it will stay running longer.