### PR TITLE
Nd 623 max tasks dns alarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,11 @@ apply: ## terraform apply
 	$(DOCKER_RUN_IT) terraform apply
 	$(DOCKER_RUN) /bin/bash -c "./scripts/publish_terraform_outputs.sh"
 
+.PHONY: target
+target: ## terraform target apply
+	$(DOCKER_RUN_IT) terraform apply -target=module.dns.aws_cloudwatch_metric_alarm.ecs_max_task_scale_alarm -target=module.dns.aws_sns_topic.ecs_alarm -target=module.dns.aws_sns_topic_subscription.email_subscription -target=module.dns.aws_sns_topic_subscription.slack_subscription
+	$(DOCKER_RUN) /bin/bash -c "./scripts/publish_terraform_outputs.sh"
+
 .PHONY: state-list
 state-list: ## terraform state list
 	$(DOCKER_RUN) terraform state list

--- a/Makefile
+++ b/Makefile
@@ -147,11 +147,6 @@ apply: ## terraform apply
 	$(DOCKER_RUN_IT) terraform apply
 	$(DOCKER_RUN) /bin/bash -c "./scripts/publish_terraform_outputs.sh"
 
-.PHONY: target
-target: ## terraform target apply
-	$(DOCKER_RUN_IT) terraform apply -target=module.dns.aws_cloudwatch_metric_alarm.ecs_max_task_scale_alarm -target=module.dns.aws_sns_topic.ecs_alarm -target=module.dns.aws_sns_topic_subscription.email_subscription -target=module.dns.aws_sns_topic_subscription.slack_subscription
-	$(DOCKER_RUN) /bin/bash -c "./scripts/publish_terraform_outputs.sh"
-
 .PHONY: state-list
 state-list: ## terraform state list
 	$(DOCKER_RUN) terraform state list

--- a/data.tf
+++ b/data.tf
@@ -156,6 +156,6 @@ data "aws_ssm_parameter" "shared_services_account_id" {
 }
 
 data "aws_ssm_parameter" "dhcp_dns_slack_webhook" {
-  name = "/staff-device/sns/dhcp_dns_slack_webhook"
+  name            = "/staff-device/sns/dhcp_dns_slack_webhook"
   with_decryption = true
 }

--- a/data.tf
+++ b/data.tf
@@ -154,7 +154,8 @@ data "aws_ssm_parameter" "shared_services_account_id" {
   name            = "/codebuild/staff_device_shared_services_account_id"
   with_decryption = true
 }
+
 data "aws_ssm_parameter" "dhcp_dns_slack_webhook" {
-  name = "/codebuild/pttp-ci-datasource-config-pipeline/production/mojo-staff-device-dhcp-dns-alerts_slackwebhook"
+  name = "/staff-device/sns/dhcp_dns_slack_webhook"
   with_decryption = true
 }

--- a/data.tf
+++ b/data.tf
@@ -154,3 +154,7 @@ data "aws_ssm_parameter" "shared_services_account_id" {
   name            = "/codebuild/staff_device_shared_services_account_id"
   with_decryption = true
 }
+data "aws_ssm_parameter" "dhcp_dns_slack_webhook" {
+  name = "/codebuild/pttp-ci-datasource-config-pipeline/production/mojo-staff-device-dhcp-dns-alerts_slackwebhook"
+  with_decryption = true
+}

--- a/locals.tf
+++ b/locals.tf
@@ -9,6 +9,7 @@ locals {
   byoip_pool_id                           = nonsensitive(data.aws_ssm_parameter.byoip_pool_id.value)
   corsham_vm_ip                           = nonsensitive(data.aws_ssm_parameter.corsham_vm_ip.value)
   dhcp_transit_gateway_id                 = nonsensitive(data.aws_ssm_parameter.dhcp_transit_gateway_id.value)
+  dhcp_dns_slack_webhook                  = nonsensitive(data.aws_ssm_parameter.dhcp_dns_slack_webhook.value)
   dns_load_balancer_private_ip_eu_west_2a = nonsensitive(data.aws_ssm_parameter.dns_load_balancer_private_ip_eu_west_2a.value)
   dns_load_balancer_private_ip_eu_west_2b = nonsensitive(data.aws_ssm_parameter.dns_load_balancer_private_ip_eu_west_2b.value)
   dns_route53_resolver_ip_eu_west_2a      = nonsensitive(data.aws_ssm_parameter.dns_route53_resolver_ip_eu_west_2a.value)

--- a/modules/dns/cloudwatch.tf
+++ b/modules/dns/cloudwatch.tf
@@ -1,5 +1,3 @@
-
-
 resource "aws_sns_topic" "ecs_alarm" {
   count = terraform.workspace == "production" ? 1 : 0
   name  = "dns-max-scaling-ecs-alarm"
@@ -7,18 +5,17 @@ resource "aws_sns_topic" "ecs_alarm" {
 
 resource "aws_sns_topic_subscription" "slack_subscription" {
   count     = terraform.workspace == "production" ? 1 : 0
-  topic_arn = aws_sns_topic.ecs_alarm.arn
+  topic_arn = aws_sns_topic.ecs_alarm[0].arn
   protocol  = "https"
   endpoint  = var.dhcp_dns_slack_webhook
 }
 
 resource "aws_sns_topic_subscription" "email_subscription" {
-  count     = terraform.workspace == "production" ? 1 : 0
-  topic_arn = aws_sns_topic.ecs_alarm.arn
+  count     = terraform.workspace == "production" ? length(var.email_addresses) : 0
+  topic_arn = aws_sns_topic.ecs_alarm[0].arn
   protocol  = "email"
-  endpoint  = "lauren.taylor-brown@justice.gov.uk"  
+  endpoint  = var.email_addresses[count.index]
 }
-
 
 resource "aws_cloudwatch_metric_alarm" "ecs_max_task_scale_alarm" {
   count                     = terraform.workspace == "production" ? 1 : 0
@@ -29,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_max_task_scale_alarm" {
   namespace                 = "ECS/ContainerInsights"
   period                    = 60 
   statistic                 = "Maximum"
-  threshold                 = 1
+  threshold                 = 18
   alarm_description         = "Alarm when DNS service ECS task count reaches max number of tasks"
 
   dimensions = {
@@ -38,10 +35,10 @@ resource "aws_cloudwatch_metric_alarm" "ecs_max_task_scale_alarm" {
   }
 
   alarm_actions = [
-    aws_sns_topic.ecs_alarm.arn
+    aws_sns_topic.ecs_alarm[0].arn
   ]
 
   ok_actions = [
-    aws_sns_topic.ecs_alarm.arn
+    aws_sns_topic.ecs_alarm[0].arn
   ]
 }

--- a/modules/dns/cloudwatch.tf
+++ b/modules/dns/cloudwatch.tf
@@ -18,16 +18,16 @@ resource "aws_sns_topic_subscription" "email_subscription" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ecs_max_task_scale_alarm" {
-  count                     = terraform.workspace == "production" ? 1 : 0
-  alarm_name                = "ecs-max-task-count-alarm"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = 1
-  metric_name               = "RunningTaskCount"
-  namespace                 = "ECS/ContainerInsights"
-  period                    = 60 
-  statistic                 = "Maximum"
-  threshold                 = 18
-  alarm_description         = "Alarm when DNS service ECS task count reaches max number of tasks"
+  count               = terraform.workspace == "production" ? 1 : 0
+  alarm_name          = "ecs-max-task-count-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "RunningTaskCount"
+  namespace           = "ECS/ContainerInsights"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 18
+  alarm_description   = "Alarm when DNS service ECS task count reaches max number of tasks"
 
   dimensions = {
     ClusterName = aws_ecs_cluster.server_cluster.name

--- a/modules/dns/cloudwatch.tf
+++ b/modules/dns/cloudwatch.tf
@@ -1,3 +1,5 @@
+########### DNS max task alarm ########### 
+
 resource "aws_sns_topic" "ecs_alarm" {
   count = terraform.workspace == "production" ? 1 : 0
   name  = "dns-max-scaling-ecs-alarm"
@@ -42,3 +44,5 @@ resource "aws_cloudwatch_metric_alarm" "ecs_max_task_scale_alarm" {
     aws_sns_topic.ecs_alarm[0].arn
   ]
 }
+
+############################################

--- a/modules/dns/cloudwatch.tf
+++ b/modules/dns/cloudwatch.tf
@@ -1,0 +1,47 @@
+
+
+resource "aws_sns_topic" "ecs_alarm" {
+  count = terraform.workspace == "production" ? 1 : 0
+  name  = "dns-max-scaling-ecs-alarm"
+}
+
+resource "aws_sns_topic_subscription" "slack_subscription" {
+  count     = terraform.workspace == "production" ? 1 : 0
+  topic_arn = aws_sns_topic.ecs_alarm.arn
+  protocol  = "https"
+  endpoint  = var.dhcp_dns_slack_webhook
+}
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  count     = terraform.workspace == "production" ? 1 : 0
+  topic_arn = aws_sns_topic.ecs_alarm.arn
+  protocol  = "email"
+  endpoint  = "lauren.taylor-brown@justice.gov.uk"  
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "ecs_max_task_scale_alarm" {
+  count                     = terraform.workspace == "production" ? 1 : 0
+  alarm_name                = "ecs-max-task-count-alarm"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = 1
+  metric_name               = "RunningTaskCount"
+  namespace                 = "ECS/ContainerInsights"
+  period                    = 60 
+  statistic                 = "Maximum"
+  threshold                 = 1
+  alarm_description         = "Alarm when DNS service ECS task count reaches max number of tasks"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.server_cluster.name
+    ServiceName = aws_ecs_service.service.name
+  }
+
+  alarm_actions = [
+    aws_sns_topic.ecs_alarm.arn
+  ]
+
+  ok_actions = [
+    aws_sns_topic.ecs_alarm.arn
+  ]
+}

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -57,3 +57,12 @@ variable "ssm_arns" {
 variable "dhcp_dns_slack_webhook" {
   type = string
 }
+
+variable "email_addresses" {
+  type    = list(string)
+  default = [
+    "InfrastructureAutomationTeam@justice.gov.uk",
+    "mojnoc@justice.gov.uk",
+    "mojnoc_alerts@justice.gov.uk"
+  ]
+}

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -59,7 +59,7 @@ variable "dhcp_dns_slack_webhook" {
 }
 
 variable "email_addresses" {
-  type    = list(string)
+  type = list(string)
   default = [
     "InfrastructureAutomationTeam@justice.gov.uk",
     "mojnoc@justice.gov.uk",

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -53,3 +53,7 @@ variable "secret_arns" {
 variable "ssm_arns" {
   type = map(any)
 }
+
+variable "dhcp_dns_slack_webhook" {
+  type = string
+}

--- a/service_dns.tf
+++ b/service_dns.tf
@@ -1,6 +1,7 @@
 module "dns" {
   source = "./modules/dns"
 
+  dhcp_dns_slack_webhook              = local.dhcp_dns_slack_webhook
   dns_route53_resolver_ip_eu_west_2a  = local.dns_route53_resolver_ip_eu_west_2a
   dns_route53_resolver_ip_eu_west_2b  = local.dns_route53_resolver_ip_eu_west_2b
   load_balancer_private_ip_eu_west_2a = local.dns_load_balancer_private_ip_eu_west_2a


### PR DESCRIPTION
- Added CloudWatch alarm when DNS service tasks reach max count - 18
- Email subscriptions for NOC
- Slack integration using a webhook

- Resources will only be created in Production.