### PR TITLE
Narrowed range to 10.0.0.0/8 t

### DIFF
--- a/modules/dhcp/security_groups.tf
+++ b/modules/dhcp/security_groups.tf
@@ -46,7 +46,7 @@ resource "aws_security_group_rule" "dhcp_container_udp_in" {
   to_port           = 67
   protocol          = "udp"
   security_group_id = aws_security_group.dhcp_server.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = ["10.0.0.0/8"]
 }
 
 resource "aws_security_group_rule" "dhcp_container_udp_out" {


### PR DESCRIPTION
To limit exposure while maintaining required functionality to allow inbound traffic to the KEA server
ND-867